### PR TITLE
Adopt C-style names

### DIFF
--- a/onnxmltools/convert/common/ConvertContext.py
+++ b/onnxmltools/convert/common/ConvertContext.py
@@ -4,6 +4,10 @@
 # license information.
 #--------------------------------------------------------------------------
 
+import re
+import warnings
+
+
 class ConvertContext:
     '''
     The ConvertContext provides data about the conversion, specifically keeping a mapping of the old->new names as
@@ -27,6 +31,10 @@ class ConvertContext:
         return self.__generate_name(name)
 
     def __generate_name(self, name):
+        original_name = name
+        name = re.sub('[^0-9a-zA-Z]|^[0-9]', '_', name)
+        if name != original_name:
+            warnings.warn('Illegal C-style name found %s. We replace it with %s.' % (original_name, name))
         if name in self._name_override_map:
             _name = self._name_override_map[name]
         else:
@@ -35,7 +43,7 @@ class ConvertContext:
         count = 1
         gen_name = _name
         while gen_name in self._unique_name_set:
-            gen_name = "{}.{}".format(_name, count)
+            gen_name = "{}{}".format(_name, count)
             count += 1
         self._unique_name_set.add(gen_name)
         return gen_name

--- a/onnxmltools/convert/common/NodeBuilder.py
+++ b/onnxmltools/convert/common/NodeBuilder.py
@@ -74,7 +74,7 @@ class NodeBuilder:
         the tensor_name as the initializer's name.
         '''
         if tensor_name is None:
-            tensor.name = self._name + '.' + tensor.name
+            tensor.name = self._name + '_' + tensor.name
         else:
             tensor.name = tensor_name
         self._initializers.append(tensor)
@@ -82,9 +82,9 @@ class NodeBuilder:
 
     def add_value(self, value):
         '''
-        Set the name of the initializer to be node-name.value-name
+        Set the name of the initializer to be node-name_value-name
         '''
-        value_name = self._name + '.' + value.name
+        value_name = self._name + '_' + value.name
         value.name = value_name
         self._input_names.append(value_name)
         self._values.append(value)

--- a/tests/common/test_ModelBuilder.py
+++ b/tests/common/test_ModelBuilder.py
@@ -29,7 +29,7 @@ class TestModelBuilder(unittest.TestCase):
         mb.add_outputs([model_util.make_tensor_value_info('Output', onnx_proto.TensorProto.FLOAT, [1])])
         model = mb.make_model()
         self.assertEqual(len(model.graph.initializer), 1)
-        self.assertEqual(model.graph.initializer[0].name, 'bar.classes')
+        self.assertEqual(model.graph.initializer[0].name, 'bar_classes')
 
     def test_intitializers_on_multiple_nodes(self):
         context = ConvertContext()
@@ -57,6 +57,6 @@ class TestModelBuilder(unittest.TestCase):
         mb.add_outputs([model_util.make_tensor_value_info('Output', onnx_proto.TensorProto.FLOAT, [1])])
         model = mb.make_model()
         self.assertEqual(len(model.graph.initializer), 2)
-        self.assertEqual(model.graph.initializer[0].name, 'bar.classes')
-        self.assertEqual(model.graph.initializer[1].name, 'bar2.classes2')
+        self.assertEqual(model.graph.initializer[0].name, 'bar_classes')
+        self.assertEqual(model.graph.initializer[1].name, 'bar2_classes2')
 

--- a/tests/common/test_NodeBuilder.py
+++ b/tests/common/test_NodeBuilder.py
@@ -21,7 +21,7 @@ class TestNodeBuilder(unittest.TestCase):
         node = nb.make_node()
 
         self.assertEqual(len(node.initializers), 1)
-        self.assertEqual(node.initializers[0].name, 'bar.classes')
+        self.assertEqual(node.initializers[0].name, 'bar_classes')
 
     def test_multiple_initializers(self):
         context = ConvertContext()
@@ -41,10 +41,10 @@ class TestNodeBuilder(unittest.TestCase):
         node = nb.make_node()
 
         self.assertEqual(len(node.initializers), 4)
-        self.assertEqual(node.initializers[0].name, 'bar.classes1')
-        self.assertEqual(node.initializers[1].name, 'bar.classes2')
-        self.assertEqual(node.initializers[2].name, 'bar.classes3')
-        self.assertEqual(node.initializers[3].name, 'bar.classes4')
+        self.assertEqual(node.initializers[0].name, 'bar_classes1')
+        self.assertEqual(node.initializers[1].name, 'bar_classes2')
+        self.assertEqual(node.initializers[2].name, 'bar_classes3')
+        self.assertEqual(node.initializers[3].name, 'bar_classes4')
 
 
     def test_value(self):
@@ -59,7 +59,7 @@ class TestNodeBuilder(unittest.TestCase):
         node = nb.make_node()
 
         self.assertEqual(len(node.values), 1)
-        self.assertEqual(node.values[0].name, 'bar.value_test')
+        self.assertEqual(node.values[0].name, 'bar_value_test')
 
     def test_add_inputs(self):
         context = ConvertContext()
@@ -80,5 +80,5 @@ class TestNodeBuilder(unittest.TestCase):
         self.assertEqual(len(input_names),5)
 
         # Confirm the order of the names based upon when added
-        expected_names = ['test','','value_test','foo.init', 'foo.value']
+        expected_names = ['test','','value_test','foo_init', 'foo_value']
         self.assertEqual(input_names, expected_names)

--- a/tests/coreml/test_coreml_convert.py
+++ b/tests/coreml/test_coreml_convert.py
@@ -15,7 +15,7 @@ class TestCoremlConverter(unittest.TestCase):
 
         result = _resolve_name_conflicts(context, inputs, outputs)
         self.assertEqual(len(result), 3)
-        expected = ['test.1', 'foo', 'bar']
+        expected = ['test3', 'foo', 'bar']
         self.assertEqual(result, expected)
 
     def test_resolve_name_conflicts_no_conflicts(self):
@@ -40,7 +40,7 @@ class TestCoremlConverter(unittest.TestCase):
         context.get_onnx_name(input)
 
         result = _resolve_name_conflicts(context, input, output)
-        expected = 'foo.1'
+        expected = 'foo1'
         self.assertEqual(result, expected)
 
     def test_resolve_name_no_conflicts_string(self):


### PR DESCRIPTION
Currently, we have some special symbols in our variable/operator names but ONNX requires C-style. This PR fixes this problem. I know it's a bit dangerous to use "_" because CoreML uses it in their names frequently. This risk will be resolved by our new framework (#12 )