### PR TITLE
Remove unsupported attribute (onnx-1.1.2)

### DIFF
--- a/onnxmltools/convert/coreml/operator_converters/neural_network/Pool.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/Pool.py
@@ -193,7 +193,6 @@ def convert_pooling(scope, operator, container):
     strides = [1, 1] if len(params.stride) <= 0 else params.stride
     attrs['kernel_shape'] = kernel_shape
     attrs['strides'] = strides
-    attrs['dilations'] = [1, 1]  # Required by runtime but useless in ONNX
 
     # Set up padding attributes
     pads = None


### PR DESCRIPTION
Pool doesn't have dilation attribute now so we remove it. If you find a runtime still needs this attribute, please use WinMLTools.