### PR TITLE
Revise shape calculators for producing Sequence of Maps (onnx-1.2)

### DIFF
--- a/onnxmltools/convert/coreml/_parse.py
+++ b/onnxmltools/convert/coreml/_parse.py
@@ -414,7 +414,7 @@ def _parse_neural_network_model(topology, parent_scope, model, inputs, outputs):
         operator.outputs.append(parent_variable)
 
 
-def parse_coreml(model, initial_types=None):
+def parse_coreml(model, initial_types=None, targted_onnx='1.1.2'):
     '''
     This is the root function of the whole parsing procedure.
     :param model: CoreML model
@@ -437,7 +437,8 @@ def parse_coreml(model, initial_types=None):
     # Topology is shared by both of CoreML and scikit-learn conversion frameworks, so we have a wrapper class,
     # CoremlModelContainer, to make sure our topology-related functions can seamlessly handle both of CoreML and
     # scikit-learn.
-    topology = Topology(CoremlModelContainer(model), default_batch_size, initial_types, reserved_variable_names)
+    topology = Topology(CoremlModelContainer(model), default_batch_size, initial_types, reserved_variable_names,
+                        targeted_onnx=targted_onnx)
     scope = topology.declare_scope('__root__')
 
     # Instead of using CoremlModelContainer, we directly pass the model in because _parse_model is CoreML-specific.

--- a/onnxmltools/convert/coreml/_parse.py
+++ b/onnxmltools/convert/coreml/_parse.py
@@ -81,9 +81,9 @@ def parse_coreml_feature(feature_info, batch_size=1):
     elif type_name == 'dictionaryType':
         key_type = raw_type.dictionaryType.WhichOneof('KeyType')
         if key_type == 'int64KeyType':
-            return DictionaryType(Int64Type(), FloatType(), doc_string=doc_string)
+            return DictionaryType(Int64TensorType([1]), FloatTensorType([1]), doc_string=doc_string)
         elif key_type == 'stringKeyType':
-            return DictionaryType(StringType(), FloatType(), doc_string=doc_string)
+            return DictionaryType(StringTensorType([1]), FloatTensorType([1]), doc_string=doc_string)
         else:
             raise ValueError('Unsupported key type: {}'.format(key_type))
     else:

--- a/onnxmltools/convert/coreml/convert.py
+++ b/onnxmltools/convert/coreml/convert.py
@@ -46,7 +46,7 @@ def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='
         name = str(uuid4().hex)
 
     # Parse CoreML model as our internal data structure (i.e., Topology)
-    topology = parse_coreml(spec, initial_types)
+    topology = parse_coreml(spec, initial_types, targeted_onnx)
 
     # Parse CoreML description, author, and license. Those information will be attached to the final ONNX model.
     metadata = spec.description.metadata

--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -5,14 +5,15 @@
 # --------------------------------------------------------------------------
 
 from ...common._registration import register_shape_calculator
-from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type, DictionaryType, StringType
+from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type, DictionaryType, StringType,\
+    SequenceType, StringTensorType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
 
 
 def calculate_traditional_classifier_output_shapes(operator):
     '''
     For classifiers, allowed input/output patterns are
-        1. [N, C_1], ..., [N, C_n] ---> [N, 1], Map
+        1. [N, C_1], ..., [N, C_n] ---> [N, 1], Sequence of Map
         2. [N, C_1], ..., [N, C_n] ---> [N, 1]
 
     For regressors, allowed input/output patterns are
@@ -24,8 +25,8 @@ def calculate_traditional_classifier_output_shapes(operator):
     check_input_and_output_numbers(operator, input_count_range=[1, None], output_count_range=[1, 2])
     check_input_and_output_types(operator, good_input_types=[FloatTensorType, Int64TensorType, FloatType, Int64Type])
 
-    if any(len(variable.type.shape) != 2 or variable.type.shape[0] != 1 for variable in operator.inputs):
-        raise RuntimeError('Input(s) must be [1,C]-tensor(s)')
+    if any(len(variable.type.shape) != 2 for variable in operator.inputs):
+        raise RuntimeError('Input(s) must be [N, C]-tensor(s)')
 
     model_type = operator.raw_operator.WhichOneof('Type')
     if model_type == 'treeEnsembleClassifier':
@@ -37,16 +38,17 @@ def calculate_traditional_classifier_output_shapes(operator):
     else:
         raise ValueError('%s has no class label' % model_type)
 
+    N = operator.inputs[0].type.shape[0]
     if class_label_type == 'stringClassLabels':
-        operator.outputs[0].type = StringType(doc_string=operator.outputs[0].type.doc_string)
+        operator.outputs[0].type = StringTensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
-            operator.outputs[1].type = DictionaryType(StringType(), FloatType(),
-                                                      doc_string=operator.outputs[1].type.doc_string)
+            operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])),
+                                                    doc_string=operator.outputs[1].type.doc_string)
     elif class_label_type == 'int64ClassLabels':
-        operator.outputs[0].type = Int64Type(doc_string=operator.outputs[0].type.doc_string)
+        operator.outputs[0].type = Int64TensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
-            operator.outputs[1].type = DictionaryType(Int64Type(), FloatType(),
-                                                      doc_string=operator.outputs[1].type.doc_string)
+            operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])),
+                                                    doc_string=operator.outputs[1].type.doc_string)
     else:
         raise ValueError('Traditional classifier must include label information')
 

--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -40,8 +40,13 @@ def calculate_traditional_classifier_output_shapes(operator):
         raise ValueError('%s has no class label' % model_type)
 
     N = operator.inputs[0].type.shape[0]
+    if operator.targeted_onnx_version < StrictVersion('1.2'):
+        output_shape = [1, 1]
+    else:
+        output_shape = [N, 1]
+
     if class_label_type == 'stringClassLabels':
-        operator.outputs[0].type = StringTensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
+        operator.outputs[0].type = StringTensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
             if operator.targeted_onnx_version < StrictVersion('1.2'):
                 operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]),
@@ -50,7 +55,7 @@ def calculate_traditional_classifier_output_shapes(operator):
                 operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])),
                                                         doc_string=operator.outputs[1].type.doc_string)
     elif class_label_type == 'int64ClassLabels':
-        operator.outputs[0].type = Int64TensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
+        operator.outputs[0].type = Int64TensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
             if operator.targeted_onnx_version < StrictVersion('1.2'):
                 operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]),

--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -4,8 +4,9 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
-from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type, DictionaryType, StringType,\
+from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type, DictionaryType, StringType, \
     SequenceType, StringTensorType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
 
@@ -42,13 +43,21 @@ def calculate_traditional_classifier_output_shapes(operator):
     if class_label_type == 'stringClassLabels':
         operator.outputs[0].type = StringTensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
-            operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])),
-                                                    doc_string=operator.outputs[1].type.doc_string)
+            if operator.targeted_onnx_version < StrictVersion('1.2'):
+                operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]),
+                                                          doc_string=operator.outputs[1].type.doc_string)
+            else:
+                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])),
+                                                        doc_string=operator.outputs[1].type.doc_string)
     elif class_label_type == 'int64ClassLabels':
         operator.outputs[0].type = Int64TensorType([N, 1], doc_string=operator.outputs[0].type.doc_string)
         if len(operator.outputs) == 2:
-            operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])),
-                                                    doc_string=operator.outputs[1].type.doc_string)
+            if operator.targeted_onnx_version < StrictVersion('1.2'):
+                operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]),
+                                                          doc_string=operator.outputs[1].type.doc_string)
+            else:
+                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])),
+                                                        doc_string=operator.outputs[1].type.doc_string)
     else:
         raise ValueError('Traditional classifier must include label information')
 

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToLabel.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToLabel.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
 from ...common.data_types import FloatTensorType, Int64TensorType, Int64Type, StringTensorType, StringType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
@@ -20,7 +21,10 @@ def calculte_tensor_to_label_output_shapes(operator):
     check_input_and_output_types(operator, good_input_types=[FloatTensorType])
 
     N = operator.inputs[0].type.shape[0]
-    output_shape = [N, 1]
+    if operator.targeted_onnx_version < StrictVersion('1.2'):
+        output_shape = [1, 1]
+    else:
+        output_shape = [N, 1]
 
     if type(operator.outputs[0].type) in [Int64Type, Int64TensorType]:
         operator.outputs[0].type = Int64TensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToLabel.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToLabel.py
@@ -12,8 +12,7 @@ from ...common.utils import check_input_and_output_numbers, check_input_and_outp
 def calculte_tensor_to_label_output_shapes(operator):
     '''
     Allowed input/output patterns are
-        1. [1, C] ---> [1]
-        2. [N, C] ---> [N , 1]
+        1. [N, C] ---> [N, 1]
 
     Note that N must be 1 currently because TensorToProbability doesn't support batch size larger than 1.
     '''
@@ -21,22 +20,12 @@ def calculte_tensor_to_label_output_shapes(operator):
     check_input_and_output_types(operator, good_input_types=[FloatTensorType])
 
     N = operator.inputs[0].type.shape[0]
-    if type(operator.outputs[0].type) == Int64Type:
-        operator.outputs[0].type = Int64TensorType([1], doc_string=operator.outputs[0].type.doc_string)
-        # Due to the limitation of ZipMap, we are not able to produce label and class probability map for batch size
-        # greater than 1. It leads to that although the following code is semantically correct, we cannot use it.
-        # if N == 1:
-        #    operator.outputs[0].type = Int64Type()
-        # else:
-        #    operator.outputs[0].type = Int64TensorType([N, 1])
-    elif type(operator.outputs[0].type) == StringType:
-        operator.outputs[0].type = StringTensorType([1], doc_string=operator.outputs[0].type.doc_string)
-        # Due to the limitation of ZipMap, we are not able to produce label and class probability map for batch size
-        # greater than 1. It leads to that although the following code is semantically correct, we cannot use it.
-        # if N == 1:
-        #    operator.outputs[0].type = StringTensorType([N, 1])
-        # else:
-        #    operator.outputs[0].type = StringType()
+    output_shape = [N, 1]
+
+    if type(operator.outputs[0].type) in [Int64Type, Int64TensorType]:
+        operator.outputs[0].type = Int64TensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)
+    elif type(operator.outputs[0].type) in [StringType, StringTensorType]:
+        operator.outputs[0].type = StringTensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)
     else:
         raise ValueError('Unsupported label type')
 

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
@@ -5,15 +5,14 @@
 # --------------------------------------------------------------------------
 
 from ...common._registration import register_shape_calculator
-from ...common.data_types import Int64Type, StringType, DictionaryType, FloatTensorType
+from ...common.data_types import DictionaryType, FloatTensorType, SequenceType, StringTensorType, Int64TensorType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
 
 
 def calculate_tensor_to_probability_map_output_shapes(operator):
     '''
     Allowed input/output patterns are
-        1. [1, C] ---> Map
-        2. [N, C] ---> A sequence of maps
+        1. [N, C] ---> A sequence of maps
 
     Note that N must be 1 currently because ZipMap doesn't support batch size larger than 1.
     '''
@@ -29,13 +28,11 @@ def calculate_tensor_to_probability_map_output_shapes(operator):
     N = operator.inputs[0].type.shape[0]
     doc_string = operator.outputs[0].type.doc_string
     if class_label_type == 'stringClassLabels':
-        operator.outputs[0].type = DictionaryType(StringType(), FloatTensorType([1]), doc_string=doc_string)
-        # It should be a sequence of dictionary if batch size is larger than 1, but runtime don't have such a type.
-        # operator.outputs[0].type = SequenceType(DictionaryType(StringType(), FloatType()), N)
+        operator.outputs[0].type = SequenceType(
+            DictionaryType(StringTensorType([1]), FloatTensorType([1])), N, doc_string)
     elif class_label_type == 'int64ClassLabels':
-        operator.outputs[0].type = DictionaryType(Int64Type(), FloatTensorType([1]), doc_string=doc_string)
-        # It should be a sequence of dictionary if batch size is larger than 1, but runtime don't have such a type.
-        # operator.outputs[0].type = SequenceType(DictionaryType(Int64Type(), FloatType()), N)
+        operator.outputs[0].type = SequenceType(
+            DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N, doc_string)
     else:
         raise ValueError('Unsupported label type')
 

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
 from ...common.data_types import DictionaryType, FloatTensorType, SequenceType, StringTensorType, Int64TensorType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
@@ -28,11 +29,17 @@ def calculate_tensor_to_probability_map_output_shapes(operator):
     N = operator.inputs[0].type.shape[0]
     doc_string = operator.outputs[0].type.doc_string
     if class_label_type == 'stringClassLabels':
-        operator.outputs[0].type = SequenceType(
-            DictionaryType(StringTensorType([1]), FloatTensorType([1])), N, doc_string)
+        if operator.targeted_onnx_version < StrictVersion('1.2'):
+            operator.outputs[0].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]), doc_string)
+        else:
+            operator.outputs[0].type = \
+                SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N, doc_string)
     elif class_label_type == 'int64ClassLabels':
-        operator.outputs[0].type = SequenceType(
-            DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N, doc_string)
+        if operator.targeted_onnx_version < StrictVersion('1.2'):
+            operator.outputs[0].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]), doc_string)
+        else:
+            operator.outputs[0].type = \
+                SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N, doc_string)
     else:
         raise ValueError('Unsupported label type')
 

--- a/onnxmltools/convert/keras/_parse.py
+++ b/onnxmltools/convert/keras/_parse.py
@@ -74,10 +74,11 @@ def determine_tensor_type(tensor, default_batch_size, keras_shape=None):
         raise ValueError('Unable to find out a correct type for tensor %s' % tensor)
 
 
-def parse_keras(model, initial_types=None):
+def parse_keras(model, initial_types=None, targeted_onnx='1.1.2'):
     raw_model_container = KerasModelContainer(model)
 
-    topology = Topology(raw_model_container, default_batch_size=1, initial_types=initial_types)
+    topology = Topology(raw_model_container, default_batch_size=1, initial_types=initial_types,
+                        targeted_onnx=targeted_onnx)
     scope = topology.declare_scope('__root__')
 
     for node in _extract_inbound_nodes(model):

--- a/onnxmltools/convert/keras/convert.py
+++ b/onnxmltools/convert/keras/convert.py
@@ -30,7 +30,7 @@ def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='
     produced model. If ONNXMLTools cannot find a compatible ONNX python package, an error may be thrown.
     :return: An ONNX model (type: ModelProto) which is equivalent to the input Keras model
     '''
-    topology = parse_keras(model, initial_types)
+    topology = parse_keras(model, initial_types, targeted_onnx)
 
     topology.compile()
 

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -7,25 +7,25 @@
 from .common import utils
 
 
-def convert_sklearn(model, name=None, initial_types=None, doc_string=''):
+def convert_sklearn(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
     if not utils.sklearn_installed():
         raise RuntimeError('scikit-learn is not installed. Please install scikit-learn to use this feature.')
 
     from .sklearn.convert import convert
-    return convert(model, name=name, initial_types=initial_types, doc_string=doc_string)
+    return convert(model, name=name, initial_types=initial_types, doc_string=doc_string, targeted_onnx=targeted_onnx)
 
 
-def convert_coreml(model, name=None, initial_types=None, doc_string=''):
+def convert_coreml(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
     if not utils.coreml_installed():
         raise RuntimeError('coremltools is not installed. Please install coremltools to use this feature.')
 
     from .coreml.convert import convert
-    return convert(model, name=name, initial_types=initial_types, doc_string=doc_string)
+    return convert(model, name=name, initial_types=initial_types, doc_string=doc_string, targeted_onnx=targeted_onnx)
 
 
-def convert_keras(model, name=None, initial_types=None, doc_string=''):
+def convert_keras(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
     if not utils.keras_installed():
         raise RuntimeError('keras is not installed. Please install coremltools to use this feature.')
 
     from .keras.convert import convert
-    return convert(model, name, initial_types=initial_types, doc_string=doc_string)
+    return convert(model, name, initial_types=initial_types, doc_string=doc_string, targeted_onnx=targeted_onnx)

--- a/onnxmltools/convert/sklearn/_parse.py
+++ b/onnxmltools/convert/sklearn/_parse.py
@@ -148,13 +148,13 @@ def _parse_sklearn(scope, model, inputs):
         return _parse_sklearn_simple_model(scope, model, inputs)
 
 
-def parse_sklearn(model, initial_types=None):
+def parse_sklearn(model, initial_types=None, targeted_onnx='1.1.2'):
     # Put scikit-learn object into an abstract container so that our framework can work seamlessly on models created
     # with different machine learning tools.
     raw_model_container = SklearnModelContainer(model)
 
     # Declare a computational graph. It will become a representation of the input scikit-learn model after parsing.
-    topology = Topology(raw_model_container)
+    topology = Topology(raw_model_container, initial_types=initial_types, targeted_onnx=targeted_onnx)
 
     # Declare an object to provide variables' and operators' naming mechanism. In contrast to CoreML, one global scope
     # is enough for parsing scikit-learn models.

--- a/onnxmltools/convert/sklearn/convert.py
+++ b/onnxmltools/convert/sklearn/convert.py
@@ -75,7 +75,7 @@ def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='
         name = str(uuid4().hex)
 
     # Parse scikit-learn model as our internal data structure (i.e., Topology)
-    topology = parse_sklearn(model, initial_types)
+    topology = parse_sklearn(model, initial_types, targeted_onnx)
 
     # Infer variable shapes
     topology.compile()

--- a/onnxmltools/convert/sklearn/shape_calculators/LinearClassifier.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/LinearClassifier.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import six, numbers
+from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
 from ...common.data_types import Int64TensorType, FloatTensorType, StringTensorType, DictionaryType, SequenceType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
@@ -36,7 +37,10 @@ def calculate_sklearn_linear_classifier_output_shapes(operator):
         operator.outputs[0].type = StringTensorType(shape=[N, 1])
         if len(class_labels) > 2 or operator.type != 'SklearnLinearSVC':
             # For multi-class classifier, we produce a map for encoding the probabilities of all classes
-            operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N)
+            if operator.targeted_onnx_version < StrictVersion('1.2'):
+                operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]))
+            else:
+                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N)
         else:
             # For binary classifier, we produce the probability of the positive class
             operator.outputs[1].type = FloatTensorType(shape=[N, 1])
@@ -44,7 +48,10 @@ def calculate_sklearn_linear_classifier_output_shapes(operator):
         operator.outputs[0].type = Int64TensorType(shape=[N, 1])
         if len(class_labels) > 2 or operator.type != 'SklearnLinearSVC':
             # For multi-class classifier, we produce a map for encoding the probabilities of all classes
-            operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N)
+            if operator.targeted_onnx_version < StrictVersion('1.2'):
+                operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]))
+            else:
+                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N)
         else:
             # For binary classifier, we produce the probability of the positive class
             operator.outputs[1].type = FloatTensorType(shape=[N, 1])

--- a/onnxmltools/convert/sklearn/shape_calculators/SVM.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/SVM.py
@@ -7,15 +7,14 @@
 import numpy as np
 import six, numbers
 from ...common._registration import register_shape_calculator
-from ...common.data_types import Int64TensorType, FloatTensorType, StringTensorType, DictionaryType
+from ...common.data_types import Int64TensorType, FloatTensorType, StringTensorType, DictionaryType, SequenceType
 from ...common.utils import check_input_and_output_numbers, check_input_and_output_types
 
 
 def calculate_sklearn_svm_output_shapes(operator):
     '''
     For SVM classifiers, allowed input/output patterns are
-        1. [1, C] ---> [1, 1], Map
-        2. [N, C] ---> [N, 1], A sequence of map
+        1. [N, C] ---> [N, 1], A sequence of map
     Note that the second case is not allowed as long as ZipMap only produces dictionary.
 
     For SVM regressors, allowed input/output patterns are
@@ -34,17 +33,14 @@ def calculate_sklearn_svm_output_shapes(operator):
     if operator.type in ['SklearnSVC']:
         check_input_and_output_numbers(operator, input_count_range=[1, None], output_count_range=[1, 2])
 
-        if N != 1 and N != 'None':
-            # In this case, output probability map should be a sequence of dictionaries, which is not implemented yet.
-            raise RuntimeError('Currently batch size must be one')
         if len(operator.outputs) != 2:
             raise RuntimeError('Support vector classifier has two outputs')
         if all(isinstance(i, (six.string_types, six.text_type)) for i in op.classes_):
-            operator.outputs[0].type = StringTensorType([1, 1])
-            operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]))
+            operator.outputs[0].type = StringTensorType([N, 1])
+            operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N)
         elif all(isinstance(i, (numbers.Real, bool, np.bool_)) for i in op.classes_):
-            operator.outputs[0].type = Int64TensorType([1, 1])
-            operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]))
+            operator.outputs[0].type = Int64TensorType([N, 1])
+            operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N)
         else:
             raise RuntimeError('Class labels should be either all strings or all integers')
 


### PR DESCRIPTION
In ONNX-1.2, ZipMap will produce a sequence of maps. This PR provides a preview of required changes in ONNXMLTools.

Major changes:
- targeted_onnx_version is added to Topology, Scope, and Operator
- Shape calculators related to ZipMap now check Operator's targeted_onnx_version and then produce proper output types. If ONNX < 1.2, Map is produced. Otherwise, we create Seq<Map>.
