### PR TITLE
A Better Support of CoreML Embedding (onnx-1.2)

### DIFF
--- a/onnxmltools/convert/common/_apply_operation.py
+++ b/onnxmltools/convert/common/_apply_operation.py
@@ -100,13 +100,15 @@ def apply_cast(scope, input_name, output_name, container, operator_name=None, to
         raise ValueError('Attribute to must be one of %s' % allowed_type_name_and_type_enum_pairs.keys())
 
     if container.targeted_onnx_version < StrictVersion('1.2'):
+        # Convert enum to string, for example, TensorProto.INT64 to 'INT64'
         attrs['to'] = allowed_type_name_and_type_enum_pairs[to]
         op_version = 1
     else:
+        # Enum, for example, TensorProto.INT64
         attrs['to'] = to
         op_version = 7
 
-    container.add_node('BatchNormalization', input_name, output_name, op_version=op_version, **attrs)
+    container.add_node('Cast', input_name, output_name, op_version=op_version, **attrs)
 
 
 def apply_div(scope, input_names, output_name, container, operator_name=None, axis=None, broadcast=None):

--- a/onnxmltools/convert/common/_topology.py
+++ b/onnxmltools/convert/common/_topology.py
@@ -539,16 +539,6 @@ class Topology:
                         # Convert [N, C] to [N, C, 1, 1] while [N, C, H, W] is unchanged
                         variable.type.shape += [1] * (4 - len(variable.type.shape))
 
-            # Rule 2 (CoreML):
-            # Some model in ONNX accepts integers while the corresponding one in CoreML only takes floats.
-            # If it is the case, we change tensor type from float to integer.
-            if operator.type == 'embedding':
-                for variable in operator.inputs:
-                    if variable.is_root:
-                        variable.type = Int64TensorType(variable.type.shape, doc_string=variable.type.doc_string)
-                    else:
-                        raise RuntimeError('Embed operator in ONNX only accepts floats but we got integers')
-
     def _prune(self):
         # Conduct a dummy evaluation of this topology. It may set all reachable operators evaluated and all reachable
         # variables fed.
@@ -659,7 +649,7 @@ def convert_topology(topology, model_name, doc_string):
     # Fill operator sets
     i = 0
     for op_domain, op_version in container.node_domain_version_pair_sets:
-        if i  == 0 and len(onnx_model.opset_import) == 1:
+        if i == 0 and len(onnx_model.opset_import) == 1:
             # Overwrite the default operator set created by helper.make_model(...)
             op_set = onnx_model.opset_import[0]
         else:

--- a/onnxmltools/convert/coreml/operator_converters/neural_network/Embed.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/Embed.py
@@ -15,9 +15,14 @@ def convert_embedding(scope, operator, container):
     gather_attrs = {'name': gather_op_name}
 
     # Reshape the indexes we want to embed to 1-D tensor. Otherwise, ONNX Gather's output may get wrong shape.
-    reshaped_input_name = scope.get_unique_variable_name(gather_op_name + 'input_reshaped')  # 2nd input of Gather
+    reshaped_input_name = scope.get_unique_variable_name(gather_op_name + 'input_reshaped')
     container.add_node('Reshape', operator.inputs[0].full_name, reshaped_input_name,
                        name=scope.get_unique_operator_name('Reshape'), shape=[-1])
+
+    # ONNX Gather accepts integers so we add a Cast to enforce this before feeding input into ONNX Gather.
+    casted_input_name = scope.get_unique_variable_name(gather_op_name + 'input_casted')  # 2nd input of Gather
+    container.add_node('Cast', reshaped_input_name, casted_input_name,
+                       name=scope.get_unique_operator_name('Cast'), to='INT64')
 
     # Load the embedding matrix. Its shape is outputChannels-by-inputDim.
     weights = np.array(params.weights.floatValue).reshape(params.outputChannels, params.inputDim)
@@ -29,7 +34,7 @@ def convert_embedding(scope, operator, container):
     if params.hasBias:
         # Put the embedded result onto a temporal tensor
         gather_output_name = scope.get_unique_variable_name(gather_op_name + '_output')
-        container.add_node('Gather', [weights_name, reshaped_input_name], gather_output_name, **gather_attrs)
+        container.add_node('Gather', [weights_name, casted_input_name], gather_output_name, **gather_attrs)
 
         # Load the bias vector into an initializer
         bias_name = scope.get_unique_variable_name(gather_op_name + '_bias')
@@ -40,7 +45,7 @@ def convert_embedding(scope, operator, container):
                            name=scope.get_unique_operator_name('Add'), axis=1, broadcast=1)
     else:
         # This case has no bias, so we just output the result produced by the embedding node.
-        container.add_node('Gather', [weights_name, reshaped_input_name], operator.output_full_names, **gather_attrs)
+        container.add_node('Gather', [weights_name, casted_input_name], operator.output_full_names, **gather_attrs)
 
 
 register_converter('embedding', convert_embedding)


### PR DESCRIPTION
Previously, we were not able to get full funtionality of CoreML embedding layer because ONNX Gather needs interger input. After adding Cast right before ONNX, we should be good.