### PR TITLE
Add Keras end-to-end tests

### DIFF
--- a/onnxmltools/__init__.py
+++ b/onnxmltools/__init__.py
@@ -19,6 +19,7 @@ __model_version__ = 0
 
 from .convert import convert_coreml
 from .convert import convert_sklearn
+from .convert import convert_keras
 
 from .utils import load_model
 from .utils import save_model

--- a/onnxmltools/convert/keras/_parse.py
+++ b/onnxmltools/convert/keras/_parse.py
@@ -65,9 +65,10 @@ def determine_tensor_type(tensor, default_batch_size, keras_shape=None):
         raise ValueError('Unable to find out a correct type for tensor %s' % tensor)
 
 
-def parse_keras(model):
+def parse_keras(model, initial_types=None):
     raw_model_container = KerasModelContainer(model)
-    topology = Topology(raw_model_container, default_batch_size=1)
+
+    topology = Topology(raw_model_container, default_batch_size=1, initial_types=initial_types)
     scope = topology.declare_scope('__root__')
 
     for node in model.inbound_nodes:
@@ -134,4 +135,3 @@ def _parse_keras(topology, parent_scope, model, inbound_node):
 
     else:
         raise RuntimeError('Unsupported Keras component %s' % type(model))
-

--- a/onnxmltools/convert/keras/convert.py
+++ b/onnxmltools/convert/keras/convert.py
@@ -5,9 +5,6 @@
 # --------------------------------------------------------------------------
 
 from uuid import uuid4
-from ...proto import onnx_proto
-from ..common import utils
-from ..common._container import RawModelContainer
 from ..common._topology import convert_topology
 from ._parse import parse_keras
 
@@ -15,30 +12,22 @@ from ._parse import parse_keras
 from . import operator_converters
 from . import shape_calculators
 
-class KerasModelContainer(RawModelContainer):
 
-    def __init__(self, keras_model):
-        super(KerasModelContainer, self).__init__(keras_model)
-        self._input_raw_names = set()
-        self._output_raw_names = set()
+def convert(model, name=None, initial_types=None, doc_string=''):
+    '''
+    Convert Keras-Tensorflow Model and Sequence objects into Topology. Note that default batch size is 1 here instead of
+    `None` used in CoreML conversion framework. To overwrite this behavior, we can specify initial_types. Assume that a
+    Keras tensor is named input:0 and its shape is [None, 3]. If the desired batch size is 10, we can specify
+    >>> from onnxmltools.convert.common.data_types import FloatTensorType
+    >>> initial_types=[('input:0', FloatTensorType([10, 3]))]
 
-    def add_input_name(self, name):
-        self._input_raw_names.add(name)
-
-    def add_output_name(self, name):
-        self._output_raw_names.add(name)
-
-    @property
-    def input_names(self):
-        return [name for name in self._input_raw_names]
-
-    @property
-    def output_names(self):
-        return [name for name in self._output_raw_names]
-
-
-def convert(model, name=None, doc_string=''):
-    topology = parse_keras(model)
+    :param model: A Keras model (Model or Sequence object)
+    :param name: Optional graph name of the produced ONNX model
+    :param initial_types: A list providing types for some input variables. Each element is a tuple of a variable name
+    and a type defined in data_types.py.
+    :param doc_string: A string attached onto the produced ONNX model
+    '''
+    topology = parse_keras(model, initial_types)
 
     topology.compile()
 
@@ -48,4 +37,3 @@ def convert(model, name=None, doc_string=''):
     onnx_model = convert_topology(topology, name, doc_string)
 
     return onnx_model
-

--- a/onnxmltools/convert/keras/operator_converters/Dense.py
+++ b/onnxmltools/convert/keras/operator_converters/Dense.py
@@ -11,7 +11,7 @@ from ...common._registration import register_converter
 
 _activation_map = {_get_activation('sigmoid'): 'Sigmoid',
                    _get_activation('softmax'): 'Softmax',
-                   _get_activation('linear'): 'Affine',
+                   _get_activation('linear'): 'Identity',
                    _get_activation('relu'): 'Relu'}
 
 

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -23,9 +23,9 @@ def convert_coreml(model, name=None, initial_types=None, doc_string=''):
     return convert(model, name=name, initial_types=initial_types, doc_string=doc_string)
 
 
-def convert_keras(model, name=None):
+def convert_keras(model, name=None, initial_types=None, doc_string=''):
     if not utils.keras_installed():
         raise RuntimeError('keras is not installed. Please install coremltools to use this feature.')
 
     from .keras.convert import convert
-    return convert(model, name)
+    return convert(model, name, initial_types=initial_types, doc_string=doc_string)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy
 protobuf
 codecov
 tensorflow
-keras
+keras==2.0.9
 coremltools
 pandas
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy
 protobuf
 codecov
 tensorflow
-keras>=2.0.4
+keras
 coremltools
 pandas
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy
 protobuf
 codecov
 tensorflow
-keras
+keras>=2.0.4
 coremltools
 pandas
 pytest

--- a/tests/end2end/test_single_operator_with_cntk_backend.py
+++ b/tests/end2end/test_single_operator_with_cntk_backend.py
@@ -138,7 +138,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         y_reference = np.transpose(y_reference, [0, 2, 3, 1])
         y_produced = _evaluate(onnx_model_p2, x_t)
 
-        self.assertTrue(np.allclose(y_reference, y_produced, atol=1e-7))
+        self.assertTrue(np.allclose(y_reference, y_produced, atol=1e-6))
 
     def test_dense(self):
         N, C = 2, 3
@@ -259,7 +259,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         # This test is active only for CNTK
         if _find_backend() == 'caffe2':
             return 0
-        N, C, H, W = 1, 1, 3, 1
+        N, C, H, W = 2, 2, 3, 4
         x = _create_tensor(N, C, H, W)
         model = Sequential()
         model.add(BatchNormalization(beta_initializer='random_uniform', gamma_initializer='random_uniform',

--- a/tests/end2end/test_single_operator_with_cntk_backend.py
+++ b/tests/end2end/test_single_operator_with_cntk_backend.py
@@ -143,8 +143,10 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
     def test_dense(self):
         N, C = 2, 3
         x = _create_tensor(N, C)
-        model = Sequential()
-        model.add(Dense(2, input_dim=C))
+
+        input = Input(shape=(C,))
+        result = Dense(2)(input)
+        model = Model(input=input, output=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core(model, x)
@@ -153,9 +155,10 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         N, C, H, W = 1, 2, 4, 3
         x = _create_tensor(N, C, H, W)
 
-        model = Sequential()
-        model.add(Conv2D(2, kernel_size=(1, 2), strides=(1, 1), padding='valid', input_shape=(H, W, C),
-                         data_format='channels_last'))
+        input = Input(shape=(H, W, C))
+        result = Conv2D(2, kernel_size=(1, 2), strides=(1, 1), padding='valid', input_shape=(H, W, C),
+                        data_format='channels_last')(input)
+        model = Model(input=input, output=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -165,8 +168,9 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         N, C, H, W = 1, 2, 4, 3
         x = _create_tensor(N, C, H, W)
         for layer in layers_to_be_tested:
-            model = Sequential()
-            model.add(layer(2, input_shape=(H, W, C), data_format='channels_last'))
+            input = Input(shape=(H, W, C))
+            result = layer(2, data_format='channels_last')(input)
+            model = Model(input=input, output=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core_channels_last(model, x)
@@ -176,8 +180,9 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         N, C, H, W = 2, 2, 1, 1
         x = _create_tensor(N, C, H, W)
 
-        model = Sequential()
-        model.add(Conv2DTranspose(2, (2, 1), input_shape=(H, W, C), data_format='channels_last'))
+        input = Input(shape=(H, W, C))
+        result = Conv2DTranspose(2, (2, 1), data_format='channels_last')(input)
+        model = Model(input=input, output=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -218,11 +223,12 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         x = _create_tensor(N, C)
 
         for activation in activation_to_be_tested:
-            model = Sequential()
+            input = Input(shape=(C,))
             if isinstance(activation, str):
-                model.add(Activation(activation, input_shape=(3,)))
+                result = Activation(activation)(input)
             else:
-                model.add(activation(input_shape=(3,)))
+                result = activation()(input)
+            model = Model(input=input, output=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core(model, x)
@@ -234,11 +240,12 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         x = _create_tensor(N, C, H, W)
 
         for activation in activation_to_be_tested:
-            model = Sequential()
+            input = Input(shape=(H, W, C))
             if isinstance(activation, str):
-                model.add(Activation(activation, input_shape=(H, W, C)))
+                result = Activation(activation)(input)
             else:
-                model.add(activation(input_shape=(H, W, C)))
+                result = activation()(input)
+            model = Model(input=input, output=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core_channels_last(model, x)
@@ -262,10 +269,12 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         N, C, H, W = 2, 2, 3, 4
         x = _create_tensor(N, C, H, W)
         model = Sequential()
-        model.add(BatchNormalization(beta_initializer='random_uniform', gamma_initializer='random_uniform',
-                                     moving_mean_initializer='random_uniform',
-                                     moving_variance_initializer=RandomUniform(minval=0.1, maxval=0.5),
-                                     input_shape=(H, W, C)))
+        input = Input(shape=(H, W, C))
+        result = BatchNormalization(beta_initializer='random_uniform', gamma_initializer='random_uniform',
+                                    moving_mean_initializer='random_uniform',
+                                    moving_variance_initializer=RandomUniform(minval=0.1, maxval=0.5),
+                                    )(input)
+        model = Model(input=input, output=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -290,8 +299,9 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         N, C, H, W = 2, 3, 1, 2
         x = _create_tensor(N, C, H, W)
 
-        model = Sequential()
-        model.add(UpSampling2D(input_shape=(H, W, C)))
+        input = Input(shape=(H, W, C))
+        result = UpSampling2D(input)
+        model = Model(input=input, output=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)


### PR DESCRIPTION
1. Add some basic end-to-end tests
2. Fix batch normalization and dense layer conversions
3. Remove redundant class in keras/_parser.py
4. Sync Keras conversion function interface with CoreML's and scikit-learn's
5. Fix keras==2.0.9 for CI tests