### PR TITLE
Aware of recent Keras attribute name's change

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy
 protobuf
 codecov
 tensorflow
-keras==2.0.9
+keras
 coremltools
 pandas
 pytest


### PR DESCRIPTION
Keras attribute "inboud_nodes" is changed to "_inbound_nodes," so our parser needs to be fixed accordingly. With this change, the latest Keras can be supported. This PR will close [this issue](https://github.com/onnx/onnxmltools/issues/37).