### PR TITLE
Get default targeted version from installed onnx package

### DIFF
--- a/onnxmltools/convert/common/_topology.py
+++ b/onnxmltools/convert/common/_topology.py
@@ -607,7 +607,7 @@ def convert_topology(topology, model_name, doc_string, targeted_onnx):
     if targeted_onnx != onnx.__version__:
         raise RuntimeError(
             'ONNX version conflict found. The installed version is %s while the targeted version is %s' % (
-                targeted_onnx, onnx.__version__))
+                onnx.__version__, targeted_onnx))
 
     topology._initialize_graph_status_for_traversing()
 

--- a/onnxmltools/convert/coreml/convert.py
+++ b/onnxmltools/convert/coreml/convert.py
@@ -6,6 +6,7 @@
 
 import coremltools
 from uuid import uuid4
+from ...proto import onnx
 from ...proto import onnx_proto
 from ..common._topology import convert_topology
 from ._parse import parse_coreml
@@ -17,7 +18,7 @@ from .operator_converters import neural_network as nn_converters
 from .shape_calculators import neural_network as nn_shape_calculators
 
 
-def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
+def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx=onnx.__version__):
     '''
     This function converts the specified CoreML model into its ONNX counterpart. Some information such as the produced
     ONNX model name can be specified.

--- a/onnxmltools/convert/keras/convert.py
+++ b/onnxmltools/convert/keras/convert.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 from uuid import uuid4
+from ...proto import onnx
 from ..common._topology import convert_topology
 from ._parse import parse_keras
 
@@ -13,7 +14,7 @@ from . import operator_converters
 from . import shape_calculators
 
 
-def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
+def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx=onnx.__version__):
     '''
     Convert Keras-Tensorflow Model and Sequence objects into Topology. Note that default batch size is 1 here instead of
     `None` used in CoreML conversion framework. To overwrite this behavior, we can specify initial_types. Assume that a

--- a/onnxmltools/convert/sklearn/convert.py
+++ b/onnxmltools/convert/sklearn/convert.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 from uuid import uuid4
+from ...proto import onnx
 from ..common._topology import convert_topology
 from ._parse import parse_sklearn
 
@@ -13,7 +14,7 @@ from . import shape_calculators
 from . import operator_converters
 
 
-def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx='1.1.2'):
+def convert(model, name=None, initial_types=None, doc_string='', targeted_onnx=onnx.__version__):
     '''
     This function produces an equivalent ONNX model of the given scikit-learn model. The supported scikit-learn
     modules are listed below.


### PR DESCRIPTION
The targeted onnx version now is extracted form the onnx package installed. It should resolve [this issue](https://github.com/onnx/onnxmltools/issues/48).