### PR TITLE
Merge duplicated operator sets (domain_name, op_version)

### DIFF
--- a/onnxmltools/convert/common/_topology.py
+++ b/onnxmltools/convert/common/_topology.py
@@ -678,13 +678,22 @@ def convert_topology(topology, model_name, doc_string, targeted_onnx):
     # Create model
     onnx_model = helper.make_model(graph)
 
+    # Merge operator sets for the same domain, the largest version number would be kept
+    purified_operator_set = dict()
+    for op_domain, op_version in container.node_domain_version_pair_sets:
+        if op_domain not in purified_operator_set:
+            purified_operator_set[op_domain] = op_version
+        else:
+            purified_operator_set[op_domain] = max(purified_operator_set[op_domain], op_version)
+
     # Fill operator sets
     i = 0
-    for op_domain, op_version in container.node_domain_version_pair_sets:
+    for op_domain, op_version in purified_operator_set.items():
         if i == 0 and len(onnx_model.opset_import) == 1:
             # Overwrite the default operator set created by helper.make_model(...)
             op_set = onnx_model.opset_import[0]
         else:
+            # Just create one ONNX element in opset_import
             op_set = onnx_model.opset_import.add()
         op_set.domain = op_domain
         op_set.version = op_version


### PR DESCRIPTION
If there are multiple operator sets for a single domain,
we will only keep the one with the highest operator version
and drop all others.

This PR should address [this](https://github.com/onnx/onnxmltools/issues/58).
