### PR TITLE
Clean up some keras 2 Model API warnings in the test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # setup.py intermediates
 .eggs
+*.egg-info/
 dist
 
 # PyCharm files
@@ -29,3 +30,4 @@ tests/baseline/outmodels
 htmlcov
 coverage.xml
 .coverage
+temp_*.onnx

--- a/tests/end2end/test_single_operator_with_cntk_backend.py
+++ b/tests/end2end/test_single_operator_with_cntk_backend.py
@@ -160,7 +160,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
 
         input = Input(shape=(C,))
         result = Dense(2)(input)
-        model = Model(input=input, output=result)
+        model = Model(inputs=input, outputs=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core(model, x)
@@ -172,7 +172,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         input = Input(shape=(H, W, C))
         result = Conv2D(2, kernel_size=(1, 2), strides=(1, 1), padding='valid', input_shape=(H, W, C),
                         data_format='channels_last')(input)
-        model = Model(input=input, output=result)
+        model = Model(inputs=input, outputs=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -184,7 +184,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         for layer in layers_to_be_tested:
             input = Input(shape=(H, W, C))
             result = layer(2, data_format='channels_last')(input)
-            model = Model(input=input, output=result)
+            model = Model(inputs=input, outputs=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core_channels_last(model, x)
@@ -196,7 +196,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
 
         input = Input(shape=(H, W, C))
         result = Conv2DTranspose(2, (2, 1), data_format='channels_last')(input)
-        model = Model(input=input, output=result)
+        model = Model(inputs=input, outputs=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -214,7 +214,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
                 result = layer(axes=-1)([input1, input2])
             else:
                 result = layer()([input1, input2])
-            model = Model(inputs=[input1, input2], output=result)
+            model = Model(inputs=[input1, input2], outputs=result)
             model.compile(optimizer='adagrad', loss='mse')
             self._test_one_to_one_operator_core(model, [x1, x2])
 
@@ -227,7 +227,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
             input1 = Input(shape=(H, W, C))
             input2 = Input(shape=(H, W, C))
             output = layer()([input1, input2])
-            model = Model(inputs=[input1, input2], output=output)
+            model = Model(inputs=[input1, input2], outputs=output)
             model.compile(optimizer='adagrad', loss='mse')
             self._test_one_to_one_operator_core_channels_last(model, [x1, x2])
 
@@ -242,7 +242,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
                 result = Activation(activation)(input)
             else:
                 result = activation()(input)
-            model = Model(input=input, output=result)
+            model = Model(inputs=input, outputs=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core(model, x)
@@ -259,7 +259,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
                 result = Activation(activation)(input)
             else:
                 result = activation()(input)
-            model = Model(input=input, output=result)
+            model = Model(inputs=input, outputs=result)
             model.compile(optimizer='adagrad', loss='mse')
 
             self._test_one_to_one_operator_core_channels_last(model, x)
@@ -288,7 +288,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
                                     moving_mean_initializer='random_uniform',
                                     moving_variance_initializer=RandomUniform(minval=0.1, maxval=0.5),
                                     )(input)
-        model = Model(input=input, output=result)
+        model = Model(inputs=input, outputs=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -315,7 +315,7 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
 
         input = Input(shape=(H, W, C))
         result = UpSampling2D(input)
-        model = Model(input=input, output=result)
+        model = Model(inputs=input, outputs=result)
         model.compile(optimizer='adagrad', loss='mse')
 
         self._test_one_to_one_operator_core_channels_last(model, x)
@@ -373,18 +373,18 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
 
         sub_input1 = Input(shape=(C,))
         sub_mapped1 = Dense(D)(sub_input1)
-        sub_model1 = Model(input=sub_input1, output=sub_mapped1)
+        sub_model1 = Model(inputs=sub_input1, outputs=sub_mapped1)
 
         sub_input2 = Input(shape=(C,))
         sub_mapped2 = Dense(D)(sub_input2)
-        sub_model2 = Model(input=sub_input2, output=sub_mapped2)
+        sub_model2 = Model(inputs=sub_input2, outputs=sub_mapped2)
 
         input1 = Input(shape=(D,))
         input2 = Input(shape=(D,))
         mapped1_2 = sub_model1(input1)
         mapped2_2 = sub_model2(input2)
         sub_sum = Add()([mapped1_2, mapped2_2])
-        model = Model(inputs=[input1, input2], output=sub_sum)
+        model = Model(inputs=[input1, input2], outputs=sub_sum)
 
         self._test_one_to_one_operator_core(model, [x, 2 * x])
 
@@ -395,12 +395,12 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         sub_input1 = Input(shape=(C,))
         sub_mapped1 = Dense(D)(sub_input1)
         sub_output1 = Activation('sigmoid')(sub_mapped1)
-        sub_model1 = Model(input=sub_input1, output=sub_output1)
+        sub_model1 = Model(inputs=sub_input1, outputs=sub_output1)
 
         sub_input2 = Input(shape=(C,))
         sub_mapped2 = sub_model1(sub_input2)
         sub_output2 = Activation('tanh')(sub_mapped2)
-        sub_model2 = Model(input=sub_input2, output=sub_output2)
+        sub_model2 = Model(inputs=sub_input2, outputs=sub_output2)
 
         input1 = Input(shape=(D,))
         input2 = Input(shape=(D,))
@@ -410,6 +410,6 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         mapped1_3 = sub_model1(mapped1_2)
         mapped2_2 = sub_model2(mapped2_1)
         sub_sum = Add()([mapped1_3, mapped2_2])
-        model = Model(inputs=[input1, input2], output=sub_sum)
+        model = Model(inputs=[input1, input2], outputs=sub_sum)
 
         self._test_one_to_one_operator_core_keras(model, [x, 2 * x])


### PR DESCRIPTION
Some warnings like:
test_single_operator_with_cntk_backend.py:291: UserWarning: Update your Model call to the Keras 2 API: Model(outputs=Tensor("ba..., inputs=Tensor("in...).