### PR TITLE
Reshape I/O shapes for dense layer when converting CoreML models

### DIFF
--- a/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
@@ -48,7 +48,7 @@ def convert_inner_product(scope, operator, container):
         # Input shape is [N, C, 1, 1] so we expect output is also 4-D, [N, C', 1, 1].
         buffer_tensor_name = scope.get_unique_variable_name(operator.full_name + '_buffer')
         container.add_node('Gemm', [name_a, name_b, name_c], buffer_tensor_name, **attrs)
-        apply_reshape(scope, operator.inputs[0].full_name, operator.outputs[0].full_name, container,
+        apply_reshape(scope, buffer_tensor_name, operator.outputs[0].full_name, container,
                       desired_shape=[-1, int(params.outputChannels), 1, 1])
     else:
         # Input shape is [N, C], so we don't need to change Gemm's output shape.

--- a/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
@@ -5,31 +5,54 @@
 # --------------------------------------------------------------------------
 
 from .....proto import onnx_proto
+from ....common._apply_operation import apply_reshape
 from ....common._registration import register_converter
 
+
 def convert_inner_product(scope, operator, container):
-#TODO: deal with input with shape [N,C,1,1]
     params = operator.raw_operator.innerProduct
-    op_type = 'Gemm'
-    attrs = {'name': operator.full_name}
 
-    name_a = operator.inputs[0].full_name
+    # Apply pre-processing step if needed
+    if len(operator.inputs[0].type.shape) == 4:
+        # Input shape is [N, C, 1, 1]. Adjust input shape because Gemm in ONNX only takes 2-D input
+        reshaped_tensor_name = scope.get_unique_variable_name(operator.inputs[0].full_name + '_reshaped')
+        apply_reshape(scope, operator.inputs[0].full_name, reshaped_tensor_name, container,
+                      desired_shape=[-1, int(params.inputChannels)])
+        name_a = reshaped_tensor_name
+    else:
+        # Input shape is [N, C]. There is no pre-processing for applying ONNX operator.
+        name_a = operator.inputs[0].full_name
 
+    # Allocate the weights of dense layer
     name_b = scope.get_unique_variable_name(operator.full_name + '_B')
     shape_b = [params.outputChannels, params.inputChannels]
     container.add_initializer(name_b, onnx_proto.TensorProto.FLOAT, shape_b, params.weights.floatValue)
 
+    # Allocate the bias of dense layer
     name_c = scope.get_unique_variable_name(operator.full_name + '_C')
     shape_c = [params.outputChannels]
     if params.hasBias:
         container.add_initializer(name_c, onnx_proto.TensorProto.FLOAT, shape_c, params.bias.floatValue)
     else:
         container.add_initializer(name_c, onnx_proto.TensorProto.FLOAT, shape_c, [0.] * shape_b[0])
+
+    # Set up attributes for ONNX Gemm which is the counterpart of CoreML inner product layer in ONNX.
+    attrs = {'name': operator.full_name}
     attrs['alpha'] = 1.0
     attrs['beta'] = 1.0
     attrs['transA'] = 0
     attrs['transB'] = 1
 
-    container.add_node(op_type, [name_a, name_b, name_c], operator.outputs[0].full_name, **attrs)
+    # Create the major ONNX operator, Gemm, to do CoreML inner product and possibly add shape adjustment
+    if len(operator.inputs[0].type.shape) == 4:
+        # Input shape is [N, C, 1, 1] so we expect output is also 4-D, [N, C', 1, 1].
+        buffer_tensor_name = scope.get_unique_variable_name(operator.full_name + '_buffer')
+        container.add_node('Gemm', [name_a, name_b, name_c], buffer_tensor_name, **attrs)
+        apply_reshape(scope, operator.inputs[0].full_name, operator.outputs[0].full_name, container,
+                      desired_shape=[-1, int(params.outputChannels), 1, 1])
+    else:
+        # Input shape is [N, C], so we don't need to change Gemm's output shape.
+        container.add_node('Gemm', [name_a, name_b, name_c], operator.outputs[0].full_name, **attrs)
+
 
 register_converter('innerProduct', convert_inner_product)

--- a/tests/end2end/test_single_operator_with_cntk_backend.py
+++ b/tests/end2end/test_single_operator_with_cntk_backend.py
@@ -8,7 +8,9 @@ import unittest
 import coremltools
 import numpy as np
 import unittest
+import onnx
 import onnxmltools
+from distutils.version import StrictVersion
 from keras.models import Sequential, Model
 from keras.layers import Input, Dense, Conv2D, MaxPooling2D, AveragePooling2D, Conv2DTranspose, \
     Dot, Embedding, BatchNormalization, GRU, Activation, PReLU, LeakyReLU, ThresholdedReLU, Maximum, \
@@ -328,6 +330,9 @@ class TestKeras2CoreML2ONNX(unittest.TestCase):
         self._test_one_to_one_operator_core_channels_last(model, x)
 
     def test_flatten(self):
+        if StrictVersion(onnx.__version__) >= StrictVersion('1.2'):
+            # The latest CNTK release does not support the new ONNX Reshape
+            return 0
         N, C, H, W, D = 2, 3, 1, 2, 2
         x = _create_tensor(N, C, H, W)
 


### PR DESCRIPTION
In CoreML, dense layer can take either [N, C] or [N, C, 1, 1] as its input. Thus, when feeding [N, C, 1, 1]-input into ONNX Gemm, we adjust its I/O shapes for a better conversion (Gemm only accepts 2-D tensors). Address [issue 78](https://github.com/onnx/onnxmltools/issues/78).