### PR TITLE
Fix a missing "n_targets" and Gemm version

### DIFF
--- a/onnxmltools/convert/coreml/operator_converters/TreeEnsemble.py
+++ b/onnxmltools/convert/coreml/operator_converters/TreeEnsemble.py
@@ -59,6 +59,7 @@ def convert_tree_ensemble_model(scope, operator, container):
         prefix = 'target'
         nodes = raw_model.treeEnsembleRegressor.treeEnsemble.nodes
         attrs['base_values'] = raw_model.treeEnsembleRegressor.treeEnsemble.basePredictionValue
+        attrs['n_targets'] = raw_model.treeEnsembleRegressor.treeEnsemble.numPredictionDimensions
         attrs['post_transform'] = get_onnx_tree_post_transform(raw_model.treeEnsembleRegressor.postEvaluationTransform)
     else:
         raise ValueError('Unknown tree model type')

--- a/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/InnerProduct.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from distutils.version import StrictVersion
 from .....proto import onnx_proto
 from ....common._registration import register_converter
 
@@ -30,6 +31,13 @@ def convert_inner_product(scope, operator, container):
     attrs['transA'] = 0
     attrs['transB'] = 1
 
-    container.add_node(op_type, [name_a, name_b, name_c], operator.outputs[0].full_name, **attrs)
+    if container.targeted_onnx_version <= StrictVersion('1.0'):
+        op_version = 1
+    elif container.targeted_onnx_version < StrictVersion('1.2'):
+        op_version = 6
+    else:
+        op_version = 7
+
+    container.add_node(op_type, [name_a, name_b, name_c], operator.outputs[0].full_name, op_version=op_version, **attrs)
 
 register_converter('innerProduct', convert_inner_product)


### PR DESCRIPTION
"n_targets" is missing when converting Core ML regression trees. Gemm has 3 versions, 1, 6, and 7 but the current code only consider 1. Fix issue [87](https://github.com/onnx/onnxmltools/issues/87) and issue [85](https://github.com/onnx/onnxmltools/issues/85).