### PR TITLE
Fix scalar shapes when defining dictionary

### DIFF
--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -52,7 +52,7 @@ def calculate_traditional_classifier_output_shapes(operator):
                 operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]),
                                                           doc_string=operator.outputs[1].type.doc_string)
             else:
-                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])),
+                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([]), FloatTensorType([])),
                                                         doc_string=operator.outputs[1].type.doc_string)
     elif class_label_type == 'int64ClassLabels':
         operator.outputs[0].type = Int64TensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)
@@ -61,7 +61,7 @@ def calculate_traditional_classifier_output_shapes(operator):
                 operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]),
                                                           doc_string=operator.outputs[1].type.doc_string)
             else:
-                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])),
+                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([]), FloatTensorType([])),
                                                         doc_string=operator.outputs[1].type.doc_string)
     else:
         raise ValueError('Traditional classifier must include label information')

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
@@ -33,13 +33,13 @@ def calculate_tensor_to_probability_map_output_shapes(operator):
             operator.outputs[0].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]), doc_string)
         else:
             operator.outputs[0].type = \
-                SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N, doc_string)
+                SequenceType(DictionaryType(StringTensorType([]), FloatTensorType([])), N, doc_string)
     elif class_label_type == 'int64ClassLabels':
         if operator.targeted_onnx_version < StrictVersion('1.2'):
             operator.outputs[0].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]), doc_string)
         else:
             operator.outputs[0].type = \
-                SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N, doc_string)
+                SequenceType(DictionaryType(Int64TensorType([]), FloatTensorType([])), N, doc_string)
     else:
         raise ValueError('Unsupported label type')
 

--- a/onnxmltools/convert/sklearn/shape_calculators/LinearClassifier.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/LinearClassifier.py
@@ -41,7 +41,7 @@ def calculate_sklearn_linear_classifier_output_shapes(operator):
             if operator.targeted_onnx_version < StrictVersion('1.2'):
                 operator.outputs[1].type = DictionaryType(StringTensorType([1]), FloatTensorType([1]))
             else:
-                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N)
+                operator.outputs[1].type = SequenceType(DictionaryType(StringTensorType([]), FloatTensorType([])), N)
         else:
             # For binary classifier, we produce the probability of the positive class
             operator.outputs[1].type = FloatTensorType(shape=[N, 1])
@@ -52,7 +52,7 @@ def calculate_sklearn_linear_classifier_output_shapes(operator):
             if operator.targeted_onnx_version < StrictVersion('1.2'):
                 operator.outputs[1].type = DictionaryType(Int64TensorType([1]), FloatTensorType([1]))
             else:
-                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N)
+                operator.outputs[1].type = SequenceType(DictionaryType(Int64TensorType([]), FloatTensorType([])), N)
         else:
             # For binary classifier, we produce the probability of the positive class
             operator.outputs[1].type = FloatTensorType(shape=[N, 1])

--- a/onnxmltools/convert/sklearn/shape_calculators/SVM.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/SVM.py
@@ -44,7 +44,7 @@ def calculate_sklearn_svm_output_shapes(operator):
                 else:
                     # New ONNX ZipMap produces Seq<Map> type
                     operator.outputs[1].type = \
-                        SequenceType(DictionaryType(StringTensorType([1]), FloatTensorType([1])), N)
+                        SequenceType(DictionaryType(StringTensorType([]), FloatTensorType([])), N)
         elif all(isinstance(i, (numbers.Real, bool, np.bool_)) for i in op.classes_):
             operator.outputs[0].type = Int64TensorType([N, 1])
             if len(operator.outputs) == 2:
@@ -54,7 +54,7 @@ def calculate_sklearn_svm_output_shapes(operator):
                 else:
                     # New ONNX ZipMap produces Seq<Map> type
                     operator.outputs[1].type = \
-                        SequenceType(DictionaryType(Int64TensorType([1]), FloatTensorType([1])), N)
+                        SequenceType(DictionaryType(Int64TensorType([]), FloatTensorType([])), N)
         else:
             raise RuntimeError('Class labels should be either all strings or all integers')
 


### PR DESCRIPTION
Scalar is tensor with shape=[] in ONNX rather than with shape=[1]. Fix issue [86](https://github.com/onnx/onnxmltools/issues/86).