### PR TITLE
Reshape input of ZipMap if it is not 2-D.

### DIFF
--- a/onnxmltools/convert/common/_apply_operation.py
+++ b/onnxmltools/convert/common/_apply_operation.py
@@ -220,6 +220,9 @@ def apply_reciprocal(scope, input_name, output_name, container, operator_name=No
 
 
 def apply_reshape(scope, input_name, output_name, container, operator_name=None, desired_shape=None):
+    if len(list(i for i in desired_shape if i < 0)) > 1:
+        raise ValueError('There can only be one -1 in the targeted shape of a Reshape but got %s' % desired_shape)
+
     name = _create_name_or_use_existing_one(scope, 'Reshape', operator_name)
 
     if container.targeted_onnx_version < StrictVersion('1.2'):

--- a/onnxmltools/convert/coreml/operator_converters/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/operator_converters/TensorToProbabilityMap.py
@@ -16,8 +16,8 @@ def convert_tensor_to_probability_map(scope, operator, container):
     probabilities. We assume that the elements in the given probability tensor are aligned with the class labels
     specified in the CoreML model.
 
-    Notice that we currently doesn't support a CoreML classifier with a batch size larger than one because ONNX's ZipMap
-    is not able to produce a batch of dictionaries.
+    Notice that ONNX<1.2 doesn't support a CoreML classifier with a batch size larger than one because old ONNX ZipMap
+    is not able to produce a sequence of dictionaries. This issue has been fixed in ONNX-1.2.
     '''
     attrs = {'name': scope.get_unique_operator_name('ZipMap')}
 

--- a/onnxmltools/convert/coreml/operator_converters/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/operator_converters/TensorToProbabilityMap.py
@@ -4,6 +4,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import numbers
+from ...common._apply_operation import apply_reshape
 from ...common._registration import register_converter
 
 
@@ -39,7 +41,29 @@ def convert_tensor_to_probability_map(scope, operator, container):
     else:
         raise TypeError('Only neural network classifiers and pipeline classifiers are supported')
 
-    container.add_node('ZipMap', [operator.inputs[0].full_name], [operator.outputs[0].full_name],
+    input_shape = operator.inputs[0].type.shape
+    if len(operator.inputs[0].type.shape) != 2:
+        # Calculate the shape attribute of ONNX Reshape
+        if input_shape[0] != 'None':
+            N = input_shape[0]
+        else:
+            N = -1  # -1 means that this dimension is automatically determined in runtime and unknown in conversion time
+
+        if all(isinstance(i, numbers.Integral) for i in input_shape[1:]):
+            C = 1
+            for i in input_shape[1:]:
+                C *= int(i)
+        else:
+            C = -1  # -1 means that this dimension is automatically determined in runtime and unknown in conversion time
+
+        # ZipMap in ONNX only accepts [C] and [N, C] inputs. In cases of [N, C, 1, 1], we reshape the probability tensor
+        # into [N, C] before feeding it into ZipMap.
+        buffer_name = scope.get_unique_variable_name('buffer')
+        apply_reshape(scope, operator.inputs[0].full_name, buffer_name, container, desired_shape=[N, C])
+    else:
+        buffer_name = operator.inputs[0].full_name
+
+    container.add_node('ZipMap', buffer_name, operator.outputs[0].full_name,
                        op_domain='ai.onnx.ml', **attrs)
 
 

--- a/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
+++ b/onnxmltools/convert/coreml/shape_calculators/TensorToProbabilityMap.py
@@ -13,9 +13,15 @@ from ...common.utils import check_input_and_output_numbers, check_input_and_outp
 def calculate_tensor_to_probability_map_output_shapes(operator):
     '''
     Allowed input/output patterns are
-        1. [N, C] ---> A sequence of maps
+    ONNX < 1.2
+        1. [1, C] ---> ---> A map
+        2. [1, C_1, ..., C_n] ---> A map
+    ONNX >= 1.2
+        1. [N, C] ---> ---> A sequence of maps
+        2. [N, C_1, ..., C_n] ---> A sequence of maps
 
-    Note that N must be 1 currently because ZipMap doesn't support batch size larger than 1.
+    Note that N must be 1 currently if you're using ONNX<1.2 because old ZipMap doesn't produce a seqneuce of map If the
+    input is not [N, C], it will be reshaped into [N, C_1 x C_2, x ... x C_n] before being fed into ONNX ZipMap.
     '''
     check_input_and_output_numbers(operator, input_count_range=1, output_count_range=1)
     check_input_and_output_types(operator, good_input_types=[FloatTensorType])


### PR DESCRIPTION
The first dimension is assumed to be the batch size, N.
The product of all other dimensions are the feature size, C.
For example, [N, C, H, W] will be reshaped to [N, CxHxW] before
calling ZipMap.