### PR TITLE
Correctly connect ONNX LSTM Y_h to a Reshape

### DIFF
--- a/onnxmltools/convert/coreml/operator_converters/neural_network/BidirectionalLSTM.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/BidirectionalLSTM.py
@@ -348,7 +348,7 @@ def convert_bidirectional_lstm(scope, operator, container):
 
         if len(operator.outputs) > 1:
             lstm_y_h_reshape_name = scope.get_unique_variable_name(lstm_op_name + '_Y_h_reshape')
-            apply_reshape(scope, lstm_y_name, lstm_y_h_reshape_name, container, desired_shape=[2, hidden_size])
+            apply_reshape(scope, lstm_y_h_name, lstm_y_h_reshape_name, container, desired_shape=[2, hidden_size])
 
             apply_split(scope, lstm_y_h_reshape_name, [operator.outputs[1].full_name, operator.outputs[3].full_name],
                         container, split=[1, 1], axis=0)


### PR DESCRIPTION
Instead of using Y produced by ONNX LSTM, we should connect Y_h to the second Reshape for adjusting output shapes. Otherwise, the Reshape may fail because Y has extra batch dimension.