### PR TITLE
Update coreml converter classifier and regressor output shape.

### DIFF
--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -43,7 +43,7 @@ def calculate_traditional_classifier_output_shapes(operator):
     if operator.targeted_onnx_version < StrictVersion('1.2'):
         output_shape = [1, 1]
     else:
-        output_shape = [N, 1]
+        output_shape = [N]
 
     if class_label_type == 'stringClassLabels':
         operator.outputs[0].type = StringTensorType(output_shape, doc_string=operator.outputs[0].type.doc_string)

--- a/onnxmltools/convert/coreml/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Classifier.py
@@ -14,8 +14,8 @@ from ...common.utils import check_input_and_output_numbers, check_input_and_outp
 def calculate_traditional_classifier_output_shapes(operator):
     '''
     For classifiers, allowed input/output patterns are
-        1. [N, C_1], ..., [N, C_n] ---> [N, 1], Sequence of Map
-        2. [N, C_1], ..., [N, C_n] ---> [N, 1]
+        1. [N, C_1], ..., [N, C_n] ---> [N], Sequence of Map
+        2. [N, C_1], ..., [N, C_n] ---> [N]
 
     For regressors, allowed input/output patterns are
         1. [N, C_1], ..., [N, C_n] ---> [N, 1]

--- a/onnxmltools/convert/coreml/shape_calculators/Regressor.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Regressor.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
 from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type
 from ...common.utils import check_input_and_output_types
@@ -34,8 +35,10 @@ def calculate_traditional_regressor_output_shapes(operator):
         raise ValueError('Model should be one of linear model, tree-based model, and support vector machine')
 
     N = operator.inputs[0].type.shape[0]
-    operator.outputs[0].type = FloatTensorType([N, C], doc_string=operator.outputs[0].type.doc_string)
-
+    if operator.targeted_onnx_version < StrictVersion('1.2') or C > 1:
+        operator.outputs[0].type = FloatTensorType([N, C], doc_string=operator.outputs[0].type.doc_string)
+    else:
+        operator.outputs[0].type = FloatTensorType([N], doc_string=operator.outputs[0].type.doc_string)
 
 register_shape_calculator('glmRegressor', calculate_traditional_regressor_output_shapes)
 register_shape_calculator('supportVectorRegressor', calculate_traditional_regressor_output_shapes)

--- a/onnxmltools/convert/coreml/shape_calculators/Regressor.py
+++ b/onnxmltools/convert/coreml/shape_calculators/Regressor.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from distutils.version import StrictVersion
 from ...common._registration import register_shape_calculator
 from ...common.data_types import FloatTensorType, Int64TensorType, FloatType, Int64Type
 from ...common.utils import check_input_and_output_types
@@ -35,10 +34,7 @@ def calculate_traditional_regressor_output_shapes(operator):
         raise ValueError('Model should be one of linear model, tree-based model, and support vector machine')
 
     N = operator.inputs[0].type.shape[0]
-    if operator.targeted_onnx_version < StrictVersion('1.2') or C > 1:
-        operator.outputs[0].type = FloatTensorType([N, C], doc_string=operator.outputs[0].type.doc_string)
-    else:
-        operator.outputs[0].type = FloatTensorType([N], doc_string=operator.outputs[0].type.doc_string)
+    operator.outputs[0].type = FloatTensorType([N, C], doc_string=operator.outputs[0].type.doc_string)
 
 register_shape_calculator('glmRegressor', calculate_traditional_regressor_output_shapes)
 register_shape_calculator('supportVectorRegressor', calculate_traditional_regressor_output_shapes)

--- a/onnxmltools/convert/sklearn/shape_calculators/SVM.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/SVM.py
@@ -35,7 +35,7 @@ def calculate_sklearn_svm_output_shapes(operator):
         check_input_and_output_numbers(operator, input_count_range=[1, None], output_count_range=[1, 2])
 
         if all(isinstance(i, (six.string_types, six.text_type)) for i in op.classes_):
-            operator.outputs[0].type = StringTensorType([N, 1])
+            operator.outputs[0].type = StringTensorType([N])
             if len(operator.outputs) == 2:
                 if operator.targeted_onnx_version < StrictVersion('1.2'):
                     # Old ONNX ZipMap produces Map type
@@ -46,7 +46,7 @@ def calculate_sklearn_svm_output_shapes(operator):
                     operator.outputs[1].type = \
                         SequenceType(DictionaryType(StringTensorType([]), FloatTensorType([])), N)
         elif all(isinstance(i, (numbers.Real, bool, np.bool_)) for i in op.classes_):
-            operator.outputs[0].type = Int64TensorType([N, 1])
+            operator.outputs[0].type = Int64TensorType([N])
             if len(operator.outputs) == 2:
                 if operator.targeted_onnx_version < StrictVersion('1.2'):
                     # Old ONNX ZipMap produces Map type

--- a/onnxmltools/convert/sklearn/shape_calculators/SVM.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/SVM.py
@@ -15,11 +15,11 @@ from ...common.utils import check_input_and_output_numbers, check_input_and_outp
 def calculate_sklearn_svm_output_shapes(operator):
     '''
     For SVM classifiers, allowed input/output patterns are
-        1. [N, C] ---> [N, 1], A sequence of map
+        1. [N, C] ---> [N], A sequence of map
     Note that the second case is not allowed as long as ZipMap only produces dictionary.
 
     For SVM regressors, allowed input/output patterns are
-        1. [N, C] ---> [N, 1]
+        1. [N, C] ---> [N]
 
     For both of SVC and SVR, the inputs should numerical tensor(s). For SVC with batch size 1, the first output is the
     label and the second output is a map used to store all class probabilities (For a key-value pair, the value is
@@ -61,7 +61,7 @@ def calculate_sklearn_svm_output_shapes(operator):
     if operator.type in ['SklearnSVR']:
         check_input_and_output_numbers(operator, input_count_range=[1, None], output_count_range=1)
 
-        operator.outputs[0].type = FloatTensorType([N, 1])
+        operator.outputs[0].type = FloatTensorType([N])
 
 
 register_shape_calculator('SklearnSVC', calculate_sklearn_svm_output_shapes)


### PR DESCRIPTION
For the tree ensemble classifier (and this is true for other classifiers as well), one of the outputs has shape {N}, but the converter uses {N,1}. This fails some ONNX engine shape verification.