### PR TITLE
Add two common scalers in scikit-learn

### DIFF
--- a/onnxmltools/convert/sklearn/_parse.py
+++ b/onnxmltools/convert/sklearn/_parse.py
@@ -45,6 +45,8 @@ from sklearn.preprocessing import Normalizer
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import RobustScaler
 from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.preprocessing import MaxAbsScaler
 
 from lightgbm import LGBMClassifier, LGBMRegressor
 
@@ -88,7 +90,9 @@ sklearn_operator_name_map = {RobustScaler: 'SklearnRobustScaler',
                              Binarizer: 'SklearnBinarizer',
                              LGBMClassifier: 'LgbmClassifier',
                              LGBMRegressor: 'LgbmRegressor',
-                             TruncatedSVD: 'SklearnTruncatedSVD'}
+                             TruncatedSVD: 'SklearnTruncatedSVD',
+                             MinMaxScaler: 'SklearnMinMaxScaler',
+                             MaxAbsScaler: 'SklearnMaxAbsScaler'}
 
 
 def _get_sklearn_operator_name(model_type):

--- a/onnxmltools/convert/sklearn/operator_converters/Scaler.py
+++ b/onnxmltools/convert/sklearn/operator_converters/Scaler.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from sklearn.preprocessing import StandardScaler, RobustScaler
+from sklearn.preprocessing import StandardScaler, RobustScaler, MinMaxScaler, MaxAbsScaler
 from ...common._registration import register_converter
 from .common import concatenate_variables
 
@@ -33,6 +33,13 @@ def convert_sklearn_scaler(scope, operator, container):
             attrs['scale'] = 1.0 / op.scale_
         else:
             attrs['scale'] = [1.] * C
+    elif isinstance(op, MinMaxScaler):
+        attrs['scale'] = op.scale_
+        attrs['offset'] = -op.min_/(op.scale_ + 1e-8)  # Add 1e-8 to avoid divided by 0
+    elif isinstance(op, MaxAbsScaler):
+        C = operator.inputs[0].type.shape[1]
+        attrs['scale'] = 1.0 / op.scale_
+        attrs['offset'] = [0.] * C
     else:
         raise ValueError('Only scikit-learn StandardScaler and RobustScaler are supported but got %s' % type(op))
 
@@ -41,3 +48,5 @@ def convert_sklearn_scaler(scope, operator, container):
 
 register_converter('SklearnRobustScaler', convert_sklearn_scaler)
 register_converter('SklearnScaler', convert_sklearn_scaler)
+register_converter('SklearnMinMaxScaler', convert_sklearn_scaler)
+register_converter('SklearnMaxAbsScaler', convert_sklearn_scaler)

--- a/onnxmltools/convert/sklearn/shape_calculators/Scaler.py
+++ b/onnxmltools/convert/sklearn/shape_calculators/Scaler.py
@@ -43,3 +43,5 @@ def calculate_sklearn_scaler_output_shapes(operator):
 register_shape_calculator('SklearnRobustScaler', calculate_sklearn_scaler_output_shapes)
 register_shape_calculator('SklearnScaler', calculate_sklearn_scaler_output_shapes)
 register_shape_calculator('SklearnNormalizer', calculate_sklearn_scaler_output_shapes)
+register_shape_calculator('SklearnMinMaxScaler', calculate_sklearn_scaler_output_shapes)
+register_shape_calculator('SklearnMaxAbsScaler', calculate_sklearn_scaler_output_shapes)

--- a/tests/sklearn/test_ScalerConverter.py
+++ b/tests/sklearn/test_ScalerConverter.py
@@ -2,7 +2,7 @@
 Tests scikit-learn's standard scaler converter.
 """
 import unittest
-from sklearn.preprocessing import StandardScaler, RobustScaler
+from sklearn.preprocessing import StandardScaler, RobustScaler, MinMaxScaler, MaxAbsScaler
 from onnxmltools import convert_sklearn
 from onnxmltools.convert.common.data_types import Int64TensorType, FloatTensorType
 
@@ -34,6 +34,18 @@ class TestSklearnScalerConverter(unittest.TestCase):
 
     def test_robust_scaler_floats_no_scaling(self):
         model = RobustScaler(with_scaling=False)
+        model.fit([[0., 0., 3.], [1., 1., 0.], [0., 2., 1.], [1., 0., 2.]])
+        model_onnx = convert_sklearn(model, 'scaler', [('input', FloatTensorType([1, 3]))])
+        self.assertTrue(model_onnx is not None)
+
+    def test_min_max_scaler(self):
+        model = MinMaxScaler()
+        model.fit([[0., 0., 3.], [1., 1., 0.], [0., 2., 1.], [1., 0., 2.]])
+        model_onnx = convert_sklearn(model, 'scaler', [('input', FloatTensorType([1, 3]))])
+        self.assertTrue(model_onnx is not None)
+
+    def test_max_abs_scaler(self):
+        model = MaxAbsScaler()
         model.fit([[0., 0., 3.], [1., 1., 0.], [0., 2., 1.], [1., 0., 2.]])
         model_onnx = convert_sklearn(model, 'scaler', [('input', FloatTensorType([1, 3]))])
         self.assertTrue(model_onnx is not None)


### PR DESCRIPTION
This PR makes MinMaxScaler and MaxAbsScaler in scikit-learn convertible. They are tested offline because CNTK (our test backend) doesn't support Scaler.