### PR TITLE
Plumb default_batch_size for convert_* to keras/coreml

### DIFF
--- a/onnxmltools/convert/keras/_parse.py
+++ b/onnxmltools/convert/keras/_parse.py
@@ -75,11 +75,13 @@ def determine_tensor_type(tensor, default_batch_size, keras_shape=None):
         raise ValueError('Unable to find out a correct type for tensor %s' % tensor)
 
 
-def parse_keras(model, initial_types=None, target_opset=None, targeted_onnx=onnx.__version__, custom_conversion_functions=None, custom_shape_calculators=None):
+def parse_keras(model, default_batch_size=1, initial_types=None, target_opset=None, targeted_onnx=onnx.__version__,
+                custom_conversion_functions=None, custom_shape_calculators=None):
     '''
     The main parsing function of Keras Model and Sequential objects.
 
     :param model: A Keras Model or Sequential object
+    :param default_batch_size: default batch size of produced ONNX model
     :param initial_types: A list providing some types for some root variables. Each element is a tuple of a variable
     name and a type defined in data_types.py.
     :param target_opset: number, for example, 7 for ONNX 1.2, and 8 for ONNX 1.3.
@@ -91,8 +93,9 @@ def parse_keras(model, initial_types=None, target_opset=None, targeted_onnx=onnx
     '''
     raw_model_container = KerasModelContainer(model)
 
-    topology = Topology(raw_model_container, default_batch_size=1, initial_types=initial_types, target_opset=target_opset, targeted_onnx=targeted_onnx,
-                        custom_conversion_functions=custom_conversion_functions, custom_shape_calculators=custom_shape_calculators)
+    topology = Topology(raw_model_container, default_batch_size=default_batch_size, initial_types=initial_types,
+                        target_opset=target_opset, targeted_onnx=targeted_onnx, custom_conversion_functions=custom_conversion_functions,
+                        custom_shape_calculators=custom_shape_calculators)
     scope = topology.declare_scope('__root__')
 
     # Each inbound node defines an evaluation of the underlining model (if the model is called multiple times, it may

--- a/onnxmltools/convert/keras/convert.py
+++ b/onnxmltools/convert/keras/convert.py
@@ -16,17 +16,13 @@ from . import operator_converters
 from . import shape_calculators
 
 
-def convert(model, name=None, initial_types=None, doc_string='', target_opset=None, targeted_onnx=onnx.__version__,
+def convert(model, name=None, default_batch_size=1, initial_types=None, doc_string='', target_opset=None, targeted_onnx=onnx.__version__,
                 channel_first_inputs=None,custom_conversion_functions=None, custom_shape_calculators=None):
     '''
-    Convert Keras-Tensorflow Model and Sequence objects into Topology. Note that default batch size is 1 here instead of
-    `None` used in CoreML conversion framework. To overwrite this behavior, we can specify initial_types. Assume that a
-    Keras tensor is named input:0 and its shape is [None, 3]. If the desired batch size is 10, we can specify
-    >>> from onnxmltools.convert.common.data_types import FloatTensorType
-    >>> initial_types=[('input:0', FloatTensorType([10, 3]))]
-
+    Convert Keras-Tensorflow Model and Sequence objects into Topology.
     :param model: A Keras model (Model or Sequence object)
     :param name: Optional graph name of the produced ONNX model
+    :param default_batch_size: default batch size of produced ONNX model. If not set, it will be 1
     :param initial_types: A list providing types for some input variables. Each element is a tuple of a variable name
     and a type defined in data_types.py.
     :param doc_string: A string attached onto the produced ONNX model
@@ -40,7 +36,7 @@ def convert(model, name=None, initial_types=None, doc_string='', target_opset=No
     :return: An ONNX model (type: ModelProto) which is equivalent to the input Keras model
     '''
 
-    topology = parse_keras(model, initial_types,
+    topology = parse_keras(model, default_batch_size, initial_types,
                            target_opset, targeted_onnx,
                            custom_conversion_functions, custom_shape_calculators)
 

--- a/onnxmltools/convert/keras/operator_converters/Conv.py
+++ b/onnxmltools/convert/keras/operator_converters/Conv.py
@@ -4,7 +4,11 @@
 # license information.
 # --------------------------------------------------------------------------
 import numpy
-from keras.layers import Conv1D, Conv2D, Conv3D, Conv2DTranspose, Conv3DTranspose, DepthwiseConv2D
+import keras
+from distutils.version import StrictVersion
+from keras.layers import Conv1D, Conv2D, Conv3D, Conv2DTranspose, Conv3DTranspose
+if StrictVersion(keras.__version__) >= StrictVersion('2.1.5'):
+    from keras.layers import DepthwiseConv2D
 from ....proto import onnx_proto
 from ...common._apply_operation import apply_identity, apply_transpose
 from ...common._registration import register_converter
@@ -37,7 +41,7 @@ def convert_keras_conv_core(scope, operator, container, is_transpose, n_dims, in
     kernel_size = weight_params.shape[:-2]
     assert (kernel_size == op.kernel_size)
         
-    if isinstance(op, DepthwiseConv2D):
+    if StrictVersion(keras.__version__) >= StrictVersion('2.1.5') and isinstance(op, DepthwiseConv2D):
         # see https://github.com/onnx/onnx-tensorflow/pull/266/files
         dm = op.depth_multiplier
         output_channels *= dm
@@ -145,4 +149,5 @@ register_converter(Conv2D, convert_keras_conv2d)
 register_converter(Conv3D, convert_keras_conv3d)
 register_converter(Conv2DTranspose, convert_keras_conv_transpose_2d)
 register_converter(Conv3DTranspose, convert_keras_conv_transpose_3d)
-register_converter(DepthwiseConv2D, convert_keras_depthwise_conv_2d)
+if StrictVersion(keras.__version__) >= StrictVersion('2.1.5'):
+    register_converter(DepthwiseConv2D, convert_keras_depthwise_conv_2d)

--- a/onnxmltools/convert/keras/shape_calculators/Conv.py
+++ b/onnxmltools/convert/keras/shape_calculators/Conv.py
@@ -4,8 +4,12 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import keras
+from distutils.version import StrictVersion
 import numbers
-from keras.layers import Conv1D, Conv2D, Conv3D, Conv2DTranspose, Conv3DTranspose, DepthwiseConv2D, RepeatVector
+from keras.layers import Conv1D, Conv2D, Conv3D, Conv2DTranspose, Conv3DTranspose, RepeatVector
+if StrictVersion(keras.__version__) >= StrictVersion('2.1.5'):
+    from keras.layers import DepthwiseConv2D
 from ...common._registration import register_shape_calculator
 
 
@@ -32,4 +36,5 @@ register_shape_calculator(Conv2D, calculate_keras_conv_output_shapes)
 register_shape_calculator(Conv3D, calculate_keras_conv_output_shapes)
 register_shape_calculator(Conv2DTranspose, calculate_keras_conv_output_shapes)
 register_shape_calculator(Conv3DTranspose, calculate_keras_conv_output_shapes)
-register_shape_calculator(DepthwiseConv2D, calculate_keras_depthwise_conv_output_shapes)
+if StrictVersion(keras.__version__) >= StrictVersion('2.1.5'):
+    register_shape_calculator(DepthwiseConv2D, calculate_keras_depthwise_conv_output_shapes)

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -20,12 +20,13 @@ def convert_coreml(model, name=None, initial_types=None, doc_string='', target_o
 
 def convert_keras(model, name=None, initial_types=None, doc_string='',
                   target_opset=None, targeted_onnx=onnx.__version__,
-                  channel_first_inputs=None, custom_conversion_functions=None, custom_shape_calculators=None):
+                  channel_first_inputs=None, custom_conversion_functions=None, custom_shape_calculators=None,
+                  default_batch_size=1):
     if not utils.keras_installed():
         raise RuntimeError('keras is not installed. Please install it to use this feature.')
 
     from .keras.convert import convert
-    return convert(model, name, initial_types, doc_string, target_opset, targeted_onnx,
+    return convert(model, name, default_batch_size, initial_types, doc_string, target_opset, targeted_onnx,
                    channel_first_inputs, custom_conversion_functions, custom_shape_calculators)
 
 


### PR DESCRIPTION
Adding the capability to set default_batch_size on convert_keras and convert_coreml calls. This is much easier than trying to use initialize_types to try and do the same thing. As asked in a previous issue, I have gone through the keras code and concluded that indeed for Keras, the first dimension is always the batch dimension. Therefore using the same logic for coreml which has the same location for the batch dimension should be okay. The clearest example of such is the following reference code for keras reference implementation for batch_flatten backend function:

def batch_flatten(x):
    return np.reshape(x, (x.shape[0], -1))