### PR TITLE
Fixing multiply, LeakyReLU in CoreML conversion (resolving #295)

### DIFF
--- a/onnxmltools/convert/coreml/operator_converters/neural_network/Multiply.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/Multiply.py
@@ -13,7 +13,7 @@ def convert_multiply(scope, operator, container):
     if len(operator.input_full_names) == 1:
         # Multiply the input tensor by a scalar, named alpha.
         scaler_name = scope.get_unique_variable_name(operator.full_name + '_B')
-        container.add_initializer(scaler_name, onnx_proto.TensorProto.FLOAT, [], [operator.raw_operator.add.alpha])
+        container.add_initializer(scaler_name, onnx_proto.TensorProto.FLOAT, [], [operator.raw_operator.multiply.alpha])
         inputs = [operator.inputs[0].full_name, scaler_name]
         broadcast = 1
         apply_mul(scope, inputs, operator.output_full_names, container, operator_name=operator.full_name,


### PR DESCRIPTION
Updating CoreML operator input name in multiply.py, as noticed in #295 for a LeakyReLU conversion.