### PR TITLE
feat: add support for lightgbm.Booster

### DIFF
--- a/onnxmltools/convert/lightgbm/convert.py
+++ b/onnxmltools/convert/lightgbm/convert.py
@@ -5,6 +5,10 @@
 # --------------------------------------------------------------------------
 
 from uuid import uuid4
+
+import lightgbm
+
+from onnxmltools.convert.lightgbm._parse import WrappedBooster
 from ...proto import onnx, get_opset_number_from_onnx
 from ..common._topology import convert_topology
 from ._parse import parse_lightgbm
@@ -21,10 +25,11 @@ def convert(model, name=None, initial_types=None, doc_string='', target_opset=No
     This function produces an equivalent ONNX model of the given lightgbm model.
     The supported lightgbm modules are listed below.
     
-    * `LGBMClassifiers <http://lightgbm.readthedocs.io/en/latest/Python-API.html#lightgbm.LGBMClassifier>`_
-    * `LGBMRegressor <http://lightgbm.readthedocs.io/en/latest/Python-API.html#lightgbm.LGBMRegressor>`_
+    * `LGBMClassifiers <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html>`_
+    * `LGBMRegressor <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html>`_
+    * `Booster <https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.Booster.html>`_
 
-    :param model: A lightgbm model
+    :param model: A LightGBM model
     :param initial_types: a python list. Each element is a tuple of a variable name and a type defined in data_types.py
     :param name: The name of the graph (type: GraphProto) in the produced ONNX model (type: ModelProto)
     :param doc_string: A string attached onto the produced ONNX model
@@ -36,8 +41,10 @@ def convert(model, name=None, initial_types=None, doc_string='', target_opset=No
     :return: An ONNX model (type: ModelProto) which is equivalent to the input lightgbm model
     '''
     if initial_types is None:
-        raise ValueError('Initial types are required. See usage of convert(...) in \
-                           onnxmltools.convert.lightgbm.convert for details')
+        raise ValueError('Initial types are required. See usage of convert(...) in '
+                         'onnxmltools.convert.lightgbm.convert for details')
+    if isinstance(model, lightgbm.Booster):
+        model = WrappedBooster(model)
     if name is None:
         name = str(uuid4().hex)
 

--- a/onnxmltools/utils/utils_backend_onnxruntime.py
+++ b/onnxmltools/utils/utils_backend_onnxruntime.py
@@ -4,6 +4,8 @@ Helpers to test runtimes.
 import os
 import glob
 import pickle
+import warnings
+
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from .utils_backend import load_data_and_model, extract_options, ExpectedAssertionError, OnnxRuntimeAssertionError, compare_outputs

--- a/tests/lightgbm/test_LightGbmTreeEnsembleConverters.py
+++ b/tests/lightgbm/test_LightGbmTreeEnsembleConverters.py
@@ -5,13 +5,15 @@
 # --------------------------------------------------------------------------
 
 import unittest
+
+import lightgbm
 import numpy
 from lightgbm import LGBMClassifier, LGBMRegressor
-from onnxmltools import convert_lightgbm
 from onnxmltools.convert.common.data_types import FloatTensorType
 from onnxmltools.utils import dump_data_and_model
 from onnxmltools.utils import dump_binary_classification, dump_multiple_classification
-from onnxmltools.utils import dump_multiple_regression, dump_single_regression
+from onnxmltools.utils import dump_single_regression
+from onnxmltools.utils.tests_helper import convert_model
 
 
 class TestLightGbmTreeEnsembleModels(unittest.TestCase):
@@ -32,6 +34,33 @@ class TestLightGbmTreeEnsembleModels(unittest.TestCase):
     def test_lightgbm_regressor2(self):
         model = LGBMRegressor(n_estimators=2, max_depth=1, min_child_samples=1)
         dump_single_regression(model, suffix="2")
+
+    def test_lightgbm_booster_classifier(self):
+        X = [[0, 1], [1, 1], [2, 0], [1, 2]]
+        X = numpy.array(X, dtype=numpy.float32)
+        y = [0, 1, 0, 1]
+        data = lightgbm.Dataset(X, label=y)
+        model = lightgbm.train({'boosting_type': 'gbdt', 'objective': 'binary',
+                                'n_estimators': 3, 'min_child_samples': 1},
+                               data)
+        model_onnx, prefix = convert_model(model, 'tree-based multi-output classifier',
+                                           [('input', FloatTensorType([1, 2]))])
+        dump_data_and_model(X, model, model_onnx,
+                            allow_failure="StrictVersion(onnx.__version__) < StrictVersion('1.3.0')",
+                            basename=prefix + "BoosterBin" + model.__class__.__name__)
+
+    def test_lightgbm_booster_regressor(self):
+        X = [[0, 1], [1, 1], [2, 0]]
+        X = numpy.array(X, dtype=numpy.float32)
+        y = [0, 1, 1.1]
+        data = lightgbm.Dataset(X, label=y)
+        model = lightgbm.train({'boosting_type': 'gbdt', 'objective': 'regression',
+                                'n_estimators': 3, 'min_child_samples': 1, 'max_depth': 1},
+                               data)
+        model_onnx, prefix = convert_model(model, 'tree-based binary classifier',
+                                           [('input', FloatTensorType([1, 2]))])
+        dump_data_and_model(X, model, model_onnx,
+                            basename=prefix + "BoosterBin" + model.__class__.__name__)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For users who need to train a LightGBM model on huge datasets that do
not fit the memory, they often choose to train through the Booster API,
which supports two_round loading of huge datasets, or the command line,
which exports a model.txt file that can only be reconstructed to a
Booster. Currently the ONNX converter does not support either case.

Most of the converter work is about processing information from the
dumped model dictionary. Other information can also be inferred from
that information as well. Here we wrap the Booster information to
facilitate the conversion process.