### PR TITLE
Fixing sklearn imputer discrepancy in v0.22

### DIFF
--- a/tests/coreml/test_cml_ImputerConverter.py
+++ b/tests/coreml/test_cml_ImputerConverter.py
@@ -4,7 +4,7 @@ Tests CoreML Imputer converter.
 import coremltools
 import numpy as np
 import unittest
-from sklearn.preprocessing import Imputer
+from sklearn.impute import SimpleImputer
 from onnxmltools.convert.coreml.convert import convert
 from onnxmltools.utils import dump_data_and_model
 
@@ -12,7 +12,7 @@ from onnxmltools.utils import dump_data_and_model
 class TestCoreMLImputerConverter(unittest.TestCase):
 
     def test_imputer(self):
-        model = Imputer(missing_values='NaN', strategy='mean', axis=0)
+        model = SimpleImputer(missing_values='NaN', strategy='mean')
         data = [[1, 2], [np.nan, 3], [7, 6]]
         model.fit(data)
         model_coreml = coremltools.converters.sklearn.convert(model)


### PR DESCRIPTION
Imputer moved from preprocessing to impute sub-library in sklearn.