### PR TITLE
Install coremltools 3.1 instead of master

### DIFF
--- a/.azure-pipelines/win32-CI-nightly.yml
+++ b/.azure-pipelines/win32-CI-nightly.yml
@@ -17,7 +17,7 @@ jobs:
         python.version: '3.6'
         ONNX_PATH: onnx==1.6.0
         ONNXRT_PATH: -i https://test.pypi.org/simple/ ort-nightly
-        COREML_PATH: git+https://github.com/apple/coremltools
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
     maxParallel: 3
 
   steps:

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -23,19 +23,19 @@ jobs:
         python.version: '3.6'
         ONNX_PATH: onnx==1.4.1
         ONNXRT_PATH: onnxruntime==0.3.0
-        COREML_PATH: git+https://github.com/apple/coremltools
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
       Python37:
         python.version: '3.7'
         ONNX_PATH: onnx==1.5.0
         ONNXRT_PATH: onnxruntime==0.4.0
-        COREML_PATH: git+https://github.com/apple/coremltools
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
       Python37-RT100:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
         ONNXRT_PATH: onnxruntime==1.0.0
-        COREML_PATH: git+https://github.com/apple/coremltools
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
     maxParallel: 3
 


### PR DESCRIPTION
Coremltools master has a bug in PR 563 which breaks our windows nightly build. Use tag 3.1 instead.