### PR TITLE
Ping h2o version==3.28.0.3 to fix nightly build

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ codecov
 coremltools
 cython
 lightgbm
-h2o
+h2o==3.28.0.3
 mleap
 numpy
 openpyxl


### PR DESCRIPTION
h2o 3.28.1.2 breaks the nightly build