### PR TITLE
Update XGBoost.py

### DIFF
--- a/onnxmltools/convert/xgboost/operator_converters/XGBoost.py
+++ b/onnxmltools/convert/xgboost/operator_converters/XGBoost.py
@@ -75,7 +75,7 @@ class XGBConverter:
                             feature_id))
             else:
                 try:
-                    feature_id = int(feature_id)
+                    feature_id = int(float(feature_id))
                 except ValueError:
                     raise RuntimeError(
                         "Unable to interpret '{0}', feature "


### PR DESCRIPTION
When the type of feature_id is float there throw an error:
"ValueError: invalid literal for int() with base 10:"
Because you get a ValueError if you pass a string representation of a float into int, or a string representation of anything but an integer (including empty string). If you do want to pass a string representation of a float to an int, as it points out above, you can convert to a float first, then to an integer.
Ref: https://stackoverflow.com/questions/1841565/valueerror-invalid-literal-for-int-with-base-10