### PR TITLE
Pin coremltools==3.1 for CI pipeline

### DIFF
--- a/.azure-pipelines/linux-CI-nightly.yml
+++ b/.azure-pipelines/linux-CI-nightly.yml
@@ -17,6 +17,7 @@ jobs:
         python.version: '3.6'
         ONNX_PATH: onnx==1.7.0
         ORT_PATH: -i https://test.pypi.org/simple/ ort-nightly
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
     maxParallel: 3
 
   steps:
@@ -35,6 +36,7 @@ jobs:
       conda install -c conda-forge protobuf
       conda install -c conda-forge numpy
       conda install -c conda-forge cmake
+      python -m pip install $(COREML_PATH)
       python -m pip install $(ONNX_PATH)
       python -m pip install tensorflow-cpu==1.15.0
       python -m pip install tf2onnx==1.5.6

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -17,26 +17,31 @@ jobs:
         python.version: '3.6'
         ONNX_PATH: onnx==1.4.1
         ONNXRT_PATH: onnxruntime==0.5.0
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: ''
       Python37-150-RT100:
         python.version: '3.7'
         ONNX_PATH: onnx==1.5.0
         ONNXRT_PATH: onnxruntime==1.0.0
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: ''
       Python37-160-RT111-XGB0:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
         ONNXRT_PATH: onnxruntime==1.1.1
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '<1.0'
       Python37-160-RT111:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
         ONNXRT_PATH: onnxruntime==1.1.1
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '>=1.0'
       Python37-170-RT130:
         python.version: '3.7'
         ONNX_PATH: onnx==1.7.0
         ONNXRT_PATH: onnxruntime==1.3.0
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '>=1.0'
     maxParallel: 3
 
@@ -56,6 +61,7 @@ jobs:
       conda install -c conda-forge protobuf
       conda install -c conda-forge numpy
       conda install -c conda-forge cmake
+      pip install $(COREML_PATH)
       pip install $(ONNX_PATH)
       python -m pip install tensorflow-cpu==1.15.0
       python -m pip install tf2onnx==1.5.6


### PR DESCRIPTION
coremltools 4.0 just gets released on pypi and breaks our linux nightly build, see
```python
import sklearn.tree as _tree
from . import _sklearn_util   
model_type = "classifier"
>   sklearn_class = _tree.DecisionTreeClassifier
E   NameError: name '_tree' is not defined
```
windows nightly build pin coremltools to 3.1 so it is fine. This change pin linux CI build to coremltools 3.1 too.
