### PR TITLE
Fix for API changes in Hummingbird 0.1.0

### DIFF
--- a/onnxmltools/convert/lightgbm/convert.py
+++ b/onnxmltools/convert/lightgbm/convert.py
@@ -62,6 +62,7 @@ def convert(model, name=None, initial_types=None, doc_string='', target_opset=No
         from hummingbird.ml import constants
 
         extra_config = {}
+        extra_config[constants.ONNX_INITIAL_TYPES] = initial_types
         extra_config[constants.ONNX_OUTPUT_MODEL_NAME] = name
         extra_config[constants.ONNX_TARGET_OPSET] = target_opset
         onnx_model = convert(onnx_ml_model, "onnx", extra_config=extra_config).model

--- a/onnxmltools/convert/lightgbm/convert.py
+++ b/onnxmltools/convert/lightgbm/convert.py
@@ -62,7 +62,6 @@ def convert(model, name=None, initial_types=None, doc_string='', target_opset=No
         from hummingbird.ml import constants
 
         extra_config = {}
-        extra_config[constants.ONNX_INITIAL_TYPES] = initial_types
         extra_config[constants.ONNX_OUTPUT_MODEL_NAME] = name
         extra_config[constants.ONNX_TARGET_OPSET] = target_opset
         onnx_model = convert(onnx_ml_model, "onnx", extra_config=extra_config).model

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,4 @@ xgboost
 catboost
 flake8
 torch==1.5.1+cpu
-hummingbird-ml
+-e git://github.com/microsoft/hummingbird#egg=hummingbird-ml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,4 @@ xgboost
 catboost
 flake8
 torch==1.5.1+cpu
--e git://github.com/microsoft/hummingbird#egg=hummingbird-ml
+hummingbird-ml==0.0.6


### PR DESCRIPTION
In the next release of Hummingbird we will deprecate the ability to pass input types to the converter. This PR makes sure that the the lightGBM converter will work with the new Hummingbird API.