### PR TITLE
Don't append threshold twice

### DIFF
--- a/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
+++ b/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
@@ -96,7 +96,8 @@ def _parse_tree_structure(tree_id, class_id, learning_rate,
                 text = text[:100000] + "\n..."
             raise TypeError("threshold must be a number not '{}'"
                             "\n{}".format(tree_structure['threshold'], text))
-    attrs['nodes_values'].append(tree_structure['threshold'])
+    else:
+        attrs['nodes_values'].append(tree_structure['threshold'])
 
     # Assume left is the true branch and right is the false branch
     attrs['nodes_truenodeids'].append(left_id)


### PR DESCRIPTION
When trying to convert a LightGBM model that uses categorical variables with `onnxmltools` and then loading it back with `onnxruntime`, I was getting a strange error message:

`ValueError: You passed in an iterable attribute but I cannot figure out its applicable type.`

This happened because the `attrs["node_values"]` property contained float and string values.

```
set([type(val) for val in attrs["node_values"]])
{<class 'str'>, <class 'float'>}
```

The reason for that is because if `tree_structure['threshold']` is a string, it is appended to `attrs['nodes_values']` twice - once as float and once as string.

I fixed it so that I only gets appended once and now it's working. 😄 