### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include onnxmltools/utils/*.js
 include onnxmltools/utils/*.css
+include requirements.txt


### PR DESCRIPTION
Thanks @xadupre for uploading the `sdist`. Sadly I cannot build from it as the `requirements.txt` file is not part of it and the `setup.py` requires it. The following PR should fix it.