### PR TITLE
add support for quantile objective for LGBM models

### DIFF
--- a/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
+++ b/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
@@ -444,7 +444,7 @@ def convert_lightgbm(scope, operator, container):
     elif gbm_text['objective'].startswith('multiclass'):
         n_classes = gbm_text['num_class']
         attrs['post_transform'] = 'SOFTMAX'
-    elif gbm_text['objective'].startswith('regression'):
+    elif gbm_text['objective'].startswith(('regression', 'quantile')):
         n_classes = 1  # Regressor has only one output variable
         attrs['post_transform'] = 'NONE'
         attrs['n_targets'] = n_classes

--- a/tests/lightgbm/test_objective_functions.py
+++ b/tests/lightgbm/test_objective_functions.py
@@ -31,6 +31,7 @@ class ObjectiveTest(unittest.TestCase):
         "regression",
         "poisson",
         "gamma",
+        "quantile"
     )
 
     @staticmethod


### PR DESCRIPTION
This PR adds support to directly convert LGBM models that use the objective 'quantile'.
There is no real difference in handling the output of a quantile model versus a regression model, since the quantile model is just a regression tuned to output a certain quantile, therefore it can be handled the same.