### PR TITLE
Fix conversion of XGBoost model after being restored - Cont

### DIFF
--- a/onnxmltools/convert/xgboost/operator_converters/XGBoost.py
+++ b/onnxmltools/convert/xgboost/operator_converters/XGBoost.py
@@ -38,7 +38,7 @@ class XGBConverter:
         booster = xgb_node.get_booster()
         # The json format was available in October 2017.
         # XGBoost 0.7 was the first version released with it.
-        js_tree_list = booster.get_dump(with_stats=True, dump_format = 'json')
+        js_tree_list = booster.get_dump(with_stats=True, dump_format='json')
         js_trees = [json.loads(s) for s in js_tree_list]
         return objective, base_score, js_trees
 

--- a/tests/hummingbirdml/test_LightGbmTreeEnsembleConverters_hummingbird.py
+++ b/tests/hummingbirdml/test_LightGbmTreeEnsembleConverters_hummingbird.py
@@ -20,6 +20,8 @@ from onnxmltools.utils.tests_helper import convert_model
 
 
 TARGET_OPSET = min(DEFAULT_OPSET_NUMBER, onnx_opset_version())
+# PyTorch 1.8.1 supports up to opset version 13.
+HUMMINGBIRD_TARGET_OPSET = min(TARGET_OPSET, 13)
 
 
 class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
@@ -46,7 +48,7 @@ class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
                                data)
         model_onnx, prefix = convert_model(model, 'tree-based classifier',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=True,
-                                           target_opset=TARGET_OPSET,
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET,
                                            zipmap=False)
         dump_data_and_model(X, model, model_onnx,
                             allow_failure="StrictVersion(onnx.__version__) < StrictVersion('1.3.0')",
@@ -63,16 +65,16 @@ class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
                                data)
         model_onnx, prefix = convert_model(model, 'tree-based classifier',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=False,
-                                           target_opset=TARGET_OPSET)
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET)
         assert "zipmap" in str(model_onnx).lower()
         with self.assertRaises(NotImplementedError):
             convert_model(model, 'tree-based classifier',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=True,
-                                           target_opset=TARGET_OPSET)
-                                           
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET)
+
         model_onnx, prefix = convert_model(model, 'tree-based classifier',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=True,
-                                           target_opset=TARGET_OPSET, zipmap=False)
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET, zipmap=False)
         dump_data_and_model(X, model, model_onnx,
                             allow_failure="StrictVersion(onnx.__version__) < StrictVersion('1.3.0')",
                             basename=prefix + "BoosterBin" + model.__class__.__name__)
@@ -88,7 +90,7 @@ class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
                                data)
         model_onnx, prefix = convert_model(model, 'tree-based classifier',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=True,
-                                           target_opset=TARGET_OPSET, zipmap=False)
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET, zipmap=False)
         dump_data_and_model(X, model, model_onnx,
                             allow_failure="StrictVersion(onnx.__version__) < StrictVersion('1.3.0')",
                             basename=prefix + "BoosterBin" + model.__class__.__name__)
@@ -108,7 +110,7 @@ class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
                                data)
         model_onnx, prefix = convert_model(model, 'tree-based binary regressor',
                                            [('input', FloatTensorType([None, 2]))], without_onnx_ml=True,
-                                           target_opset=TARGET_OPSET, zipmap=False)
+                                           target_opset=HUMMINGBIRD_TARGET_OPSET, zipmap=False)
         dump_data_and_model(X, model, model_onnx,
                             allow_failure="StrictVersion(onnx.__version__) < StrictVersion('1.0.0')",
                             basename=prefix + "BoosterBin" + model.__class__.__name__)
@@ -203,7 +205,7 @@ class TestLightGbmTreeEnsembleModelsHummingBird(unittest.TestCase):
         y = [0, 1, 1.1]
         data = lightgbm.Dataset(X, label=y)
         model = lightgbm.train(
-            {"boosting_type": "gbdt", "objective": "regression", "n_estimators": 3, 
+            {"boosting_type": "gbdt", "objective": "regression", "n_estimators": 3,
              "min_child_samples": 1, "max_depth": 1, 'num_thread': 1},
             data,
         )


### PR DESCRIPTION
Based on #506.

After being restored, the loaded booster is not exactly the same in memory. `best_ntree_limit` is not saved during `save_model`.
This PR enables `num_class` and `n_estimators` inference through `tree_info` instead of `best_ntree_limit`. 
`tree_info` is a required property for gbtree JSON schema https://xgboost.readthedocs.io/en/latest/tutorials/saving_model.html?highlight=tree_info#json-schema. 