### PR TITLE
fix: Converter for SparkML VectorAssembler does not support vector inputs correctly

### DIFF
--- a/onnxmltools/convert/sparkml/operator_converters/vector_assembler.py
+++ b/onnxmltools/convert/sparkml/operator_converters/vector_assembler.py
@@ -18,12 +18,15 @@ register_converter('pyspark.ml.feature.VectorAssembler', convert_sparkml_vector_
 
 def calculate_vector_assembler_shapes(operator):
     check_input_and_output_numbers(operator, output_count_range=1)
-    C = len(operator.raw_operator.getInputCols())
+
+    # Sum up the rank 1 (length of input vector) from each input.
+    C = sum([input.type.shape[1] for input in operator.inputs])
+    N = operator.inputs[0].type.shape[0]
     col_type = operator.inputs[0].type
     if isinstance(col_type, FloatTensorType):
-        col_type = FloatTensorType([1, C])
+        col_type = FloatTensorType([N, C])
     elif isinstance(col_type, Int64TensorType):
-        col_type = Int64TensorType([1, C])
+        col_type = Int64TensorType([N, C])
     else:
         raise TypeError("Unsupported input type")
     operator.outputs[0].type = col_type

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ mleap
 numpy
 openpyxl
 pandas
-protobuf
+protobuf<4.0
 psutil
 pyspark
 pytest

--- a/tests/sparkml/test_vector_assembler.py
+++ b/tests/sparkml/test_vector_assembler.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 import numpy
 import pandas
+from pyspark.ml.linalg import Vectors
 from pyspark.ml.feature import VectorAssembler
 from onnx.defs import onnx_opset_version
 from onnxconverter_common.onnx_ex import DEFAULT_OPSET_NUMBER
@@ -21,13 +22,12 @@ class TestSparkmlVectorAssembler(SparkMlTestCase):
     @unittest.skipIf(sys.version_info < (3, 8),
                      reason="pickle fails on python 3.7")
     def test_model_vector_assembler(self):
-        col_names = ["a", "b", "c"]
+        col_names = ["a", "b"]
         model = VectorAssembler(inputCols=col_names, outputCol='features')
-        data = self.spark.createDataFrame([(1., 0., 3.)], col_names)
+        data = self.spark.createDataFrame([(1., Vectors.dense([1.0, 2.0, 3.0]))], col_names)
         model_onnx = convert_sparkml(model, 'Sparkml VectorAssembler',  [
             ('a', FloatTensorType([None, 1])),
-            ('b', FloatTensorType([None, 1])),
-            ('c', FloatTensorType([None, 1]))
+            ('b', FloatTensorType([None, 3]))
         ], target_opset=TARGET_OPSET)
         self.assertTrue(model_onnx is not None)
         self.assertTrue(model_onnx.graph.node is not None)
@@ -36,14 +36,14 @@ class TestSparkmlVectorAssembler(SparkMlTestCase):
         expected = predicted.select("features").toPandas().features.apply(lambda x: pandas.Series(x.toArray())).values
         data_np = {
             'a': data.select('a').toPandas().values.astype(numpy.float32),
-            'b': data.select('b').toPandas().values.astype(numpy.float32),
-            'c': data.select('c').toPandas().values.astype(numpy.float32)
+            'b': data.select('b').toPandas()['b'].apply(lambda x: pandas.Series(x.toArray())).values.astype(numpy.float32),
         }
         paths = save_data_models(data_np, expected, model, model_onnx,
                                     basename="SparkmlVectorAssembler")
         onnx_model_path = paths[-1]
         output, output_shapes = run_onnx_model(['features'], data_np, onnx_model_path)
         compare_results(expected, output, decimal=5)
+        assert output_shapes == [[None, 4]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixing #553 