### PR TITLE
update CI pipeline files

### DIFF
--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -15,26 +15,29 @@ jobs:
   strategy:
     matrix:
 
+      Python310-1120-RT1120-xgb161:
+        python.version: '3.10'
+        ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
+        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+        xgboost.version: '>=1.6.1'
       Python39-1120-RT1110-xgb161:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
         ONNXRT_PATH: onnxruntime==1.11.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '>=1.6.1'
-
       Python39-1120-RT1110-xgb142:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
         ONNXRT_PATH: onnxruntime==1.11.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '==1.4.2'
-
       Python39-1110-RT1110:
         python.version: '3.9'
         ONNX_PATH: onnx==1.11.0  # '-i https://test.pypi.org/simple/ onnx==1.9.101'
         ONNXRT_PATH: onnxruntime==1.11.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
       Python39-1110-RT1100:
         python.version: '3.9'
         ONNX_PATH: onnx==1.11.0  # '-i https://test.pypi.org/simple/ onnx==1.9.101'
@@ -65,30 +68,6 @@ jobs:
         ONNXRT_PATH: onnxruntime==1.6.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '>=1.2'
-      Python37-150-RT100:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.5.0
-        ONNXRT_PATH: onnxruntime==1.0.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: ''
-      Python37-160-RT111-XGB0:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-        ONNXRT_PATH: onnxruntime==1.1.1
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '<1.0'
-      Python37-160-RT111:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-        ONNXRT_PATH: onnxruntime==1.1.1
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.0'
-      Python37-170-RT130:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.7.0
-        ONNXRT_PATH: onnxruntime==1.3.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.0'
       Python37-180-RT160:
         python.version: '3.7'
         ONNX_PATH: onnx==1.8.0

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -15,12 +15,6 @@ jobs:
   strategy:
     matrix:
 
-      Python310-1120-RT1120-xgb161:
-        python.version: '3.10'
-        ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
-        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.6.1'
       Python39-1120-RT1110-xgb161:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -14,14 +14,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-
-      Python310-1120-RT1120-xgb161:
-        python.version: '3.10'
-        ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
-        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.6.1'
-
       Python39-1120-RT1110-xgb161:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -15,6 +15,13 @@ jobs:
   strategy:
     matrix:
 
+      Python310-1120-RT1120-xgb161:
+        python.version: '3.10'
+        ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
+        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+        xgboost.version: '>=1.6.1'
+
       Python39-1120-RT1110-xgb161:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' #'-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
@@ -56,18 +63,7 @@ jobs:
         ONNXRT_PATH: onnxruntime==1.7.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
         xgboost.version: '>=1.2'
-      Python37-180-RT160-xgb11:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.8.0
-        ONNXRT_PATH: onnxruntime==1.6.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.2'
-      Python37-180-RT160:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.8.0
-        ONNXRT_PATH: onnxruntime==1.6.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-        xgboost.version: '>=1.0'
+
     maxParallel: 3
 
   steps:

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -15,12 +15,6 @@ jobs:
   strategy:
     matrix:
 
-      Python39-1120-RT1120:
-        python.version: '3.10'
-        ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
-        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
       Python39-1120-RT1110:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
@@ -61,6 +55,24 @@ jobs:
         python.version: '3.8'
         ONNX_PATH: onnx==1.8.1
         ONNXRT_PATH: onnxruntime==1.7.0
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+
+      Python37-180-RT160:
+        python.version: '3.7'
+        ONNX_PATH: onnx==1.8.0
+        ONNXRT_PATH: onnxruntime==1.6.0
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+
+      Python37-160-RT111:
+        python.version: '3.7'
+        ONNX_PATH: onnx==1.6.0
+        ONNXRT_PATH: onnxruntime==1.1.1
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+
+      Python37-170-RT130:
+        python.version: '3.7'
+        ONNX_PATH: onnx==1.7.0
+        ONNXRT_PATH: onnxruntime==1.3.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
     maxParallel: 3

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -15,6 +15,12 @@ jobs:
   strategy:
     matrix:
 
+      Python310-1120-RT1120:
+        python.version: '3.10'
+        ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
+        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+
       Python39-1120-RT1110:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
@@ -61,18 +67,6 @@ jobs:
         python.version: '3.7'
         ONNX_PATH: onnx==1.8.0
         ONNXRT_PATH: onnxruntime==1.6.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
-      Python37-160-RT111:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-        ONNXRT_PATH: onnxruntime==1.1.1
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
-      Python37-170-RT130:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.7.0
-        ONNXRT_PATH: onnxruntime==1.3.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
     maxParallel: 3

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -15,6 +15,12 @@ jobs:
   strategy:
     matrix:
 
+      Python39-1120-RT1120:
+        python.version: '3.10'
+        ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
+        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
+        COREML_PATH: git+https://github.com/apple/coremltools@3.1
+
       Python39-1120-RT1110:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
@@ -55,12 +61,6 @@ jobs:
         python.version: '3.8'
         ONNX_PATH: onnx==1.8.1
         ONNXRT_PATH: onnxruntime==1.7.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
-      Python37-180-RT160:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.8.0
-        ONNXRT_PATH: onnxruntime==1.6.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
     maxParallel: 3

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -57,24 +57,6 @@ jobs:
         ONNXRT_PATH: onnxruntime==1.7.0
         COREML_PATH: git+https://github.com/apple/coremltools@3.1
 
-      Python37-180-RT160:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.8.0
-        ONNXRT_PATH: onnxruntime==1.6.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
-      Python37-160-RT111:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.6.0
-        ONNXRT_PATH: onnxruntime==1.1.1
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
-      Python37-170-RT130:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.7.0
-        ONNXRT_PATH: onnxruntime==1.3.0
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
     maxParallel: 3
 
   steps:

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -15,12 +15,6 @@ jobs:
   strategy:
     matrix:
 
-      Python310-1120-RT1120:
-        python.version: '3.10'
-        ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'
-        ONNXRT_PATH: onnxruntime==1.12.0 #'-i https://test.pypi.org/simple/ ort-nightly==1.11.0.dev20220311003'
-        COREML_PATH: git+https://github.com/apple/coremltools@3.1
-
       Python39-1120-RT1110:
         python.version: '3.9'
         ONNX_PATH: 'onnx==1.12.0' # '-i https://test.pypi.org/simple/ onnx==1.12.0rc4'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pyspark
 pytest
 pytest-cov
 pytest-spark
-scikit-learn
-scipy==1.8.0
+scikit-learn==1.1.0
+scipy
 wheel
 xgboost==1.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,6 @@ pytest
 pytest-cov
 pytest-spark
 scikit-learn
-scipy
+scipy==1.8.0
 wheel
 xgboost==1.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,6 @@ pytest
 pytest-cov
 pytest-spark
 scikit-learn==1.1.0
-scipy
+scipy==1.8.0
 wheel
 xgboost==1.5.2

--- a/tests/svmlib/test_SVMConverters.py
+++ b/tests/svmlib/test_SVMConverters.py
@@ -5,6 +5,7 @@ Tests scikit-linear converter.
 """
 import tempfile
 import numpy
+import os
 try:
     from libsvm.svm import C_SVC as SVC, EPSILON_SVR as SVR, NU_SVC as NuSVC, NU_SVR as NuSVR
     import libsvm.svm as svm    


### PR DESCRIPTION
Signed-off-by: xiaowuhu <xiaowuhu@microsoft.com>

1. shorten the CI pipeline to reduce running time, removing onnx 1.7 and below, removing onnxruntime 1.6 and below, keep python 3.8 and above.
2. scipy 1.9.0 will break the pipeline due to some component are deprecated and removed, so stick to 1.8.0
3. scikit-learn 1.1.2 will break the pipeline due to same reason, so just stick to 1.1.0