### PR TITLE
support LGBMRanker conversion

### DIFF
--- a/onnxmltools/convert/lightgbm/_parse.py
+++ b/onnxmltools/convert/lightgbm/_parse.py
@@ -7,14 +7,15 @@ from ..common._topology import Topology
 from ..common.data_types import (FloatTensorType,
                                  SequenceType, DictionaryType, StringType, Int64Type)
 
-from lightgbm import LGBMClassifier, LGBMRegressor
+from lightgbm import LGBMClassifier, LGBMRegressor, LGBMRanker
 
 lightgbm_classifier_list = [LGBMClassifier]
 
 # Associate scikit-learn types with our operator names. If two scikit-learn models share a single name, it means their
 # are equivalent in terms of conversion.
 lightgbm_operator_name_map = {LGBMClassifier: 'LgbmClassifier',
-                              LGBMRegressor: 'LgbmRegressor'}
+                              LGBMRegressor: 'LgbmRegressor',
+                              LGBMRanker: 'LgbmRanker'}
 
 
 class WrappedBooster:
@@ -31,6 +32,8 @@ class WrappedBooster:
             self.classes_ = self._generate_classes(booster)
         elif self.objective_.startswith('regression'):
             self.operator_name = 'LgbmRegressor'
+        elif self.objective_.startswith('lambdarank'):
+            self.operator_name = 'LgbmRanker'
         else:
             raise NotImplementedError(
                 'Unsupported LightGbm objective: %r.' % self.objective_)

--- a/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
+++ b/onnxmltools/convert/lightgbm/operator_converters/LightGbm.py
@@ -455,6 +455,10 @@ def convert_lightgbm(scope, operator, container):
         # so we need to add an 'Exp' post transform node to the model
         attrs['post_transform'] = 'NONE'
         post_transform = "Exp"
+    elif gbm_text['objective'].startswith('lambdarank'):
+        n_classes = 1  # Ranker has only one output variable
+        attrs['post_transform'] = 'NONE'
+        attrs['n_targets'] = n_classes
     else:
         raise RuntimeError(
             "LightGBM objective should be cleaned already not '{}'.".format(
@@ -818,3 +822,4 @@ def convert_lgbm_zipmap(scope, operator, container):
 register_converter('LgbmClassifier', convert_lightgbm)
 register_converter('LgbmRegressor', convert_lightgbm)
 register_converter('LgbmZipMap', convert_lgbm_zipmap)
+register_converter('LgbmRanker', convert_lightgbm)

--- a/onnxmltools/convert/lightgbm/shape_calculators/Ranker.py
+++ b/onnxmltools/convert/lightgbm/shape_calculators/Ranker.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ...common._registration import register_shape_calculator
+from ...common.shape_calculator import calculate_linear_regressor_output_shapes
+
+register_shape_calculator('LgbmRanker', calculate_linear_regressor_output_shapes)

--- a/onnxmltools/convert/lightgbm/shape_calculators/__init__.py
+++ b/onnxmltools/convert/lightgbm/shape_calculators/__init__.py
@@ -3,3 +3,4 @@
 # To register shape calculators for lightgbm operators, import associated modules here.
 from . import Classifier
 from . import Regressor
+from . import Ranker


### PR DESCRIPTION
Maybe related to #338 

Since original onnxmltools only supports conversion of `LGBMRegressor` / `LGBMClassifier`, I added some more code to support conversion of `LGBMRanker`.

With this change, I found conversion succeed and inference result using onnx(by onnxruntime) was same. If I missed something, please tell me. Thank you!