### PR TITLE
convert_lightgbm: Add shape to FloatTensor probabilities

### DIFF
--- a/onnxmltools/convert/lightgbm/_parse.py
+++ b/onnxmltools/convert/lightgbm/_parse.py
@@ -148,7 +148,7 @@ def _parse_sklearn_classifier(scope, model, inputs, zipmap=True):
             SequenceType(DictionaryType(label_type, FloatTensorType())))
     else:
         output_probability = scope.declare_local_variable(
-            'probabilities', FloatTensorType())
+            'probabilities', FloatTensorType(shape=[None, len(classes)]))
     this_operator.outputs.append(output_label)
     this_operator.outputs.append(output_probability)
     return this_operator.outputs


### PR DESCRIPTION
When using convert_lightgbm, with zipmap set to false, onnx checker complains about 'probabilities' tensor that does not have a shape and the converted model cannot be used with onnxruntime.
This commit adds correct shape for this case.