### PR TITLE
Update utils.py

### DIFF
--- a/onnxmltools/convert/sparkml/utils.py
+++ b/onnxmltools/convert/sparkml/utils.py
@@ -16,14 +16,14 @@ def buildInitialTypesSimple(dataframe):
 def getTensorTypeFromSpark(sparktype):
     if sparktype == 'StringType':
         return StringTensorType([1, 1])
-    elif sparktype == 'DecimalType' \
-            or sparktype == 'DoubleType' \
-            or sparktype == 'FloatType' \
-            or sparktype == 'LongType' \
-            or sparktype == 'IntegerType' \
-            or sparktype == 'ShortType' \
-            or sparktype == 'ByteType' \
-            or sparktype == 'BooleanType':
+    elif sparktype == 'DecimalType()' \
+            or sparktype == 'DoubleType()' \
+            or sparktype == 'FloatType()' \
+            or sparktype == 'LongType()' \
+            or sparktype == 'IntegerType()' \
+            or sparktype == 'ShortType()' \
+            or sparktype == 'ByteType()' \
+            or sparktype == 'BooleanType()':
         return FloatTensorType([1, 1])
     else:
         raise TypeError("Cannot map this type to Onnx types: " + sparktype)


### PR DESCRIPTION
sparktype is being returned with the parentheses, leading to errors like "Cannot map this type to Onnx types: DoubleType()"