### PR TITLE
Fix for Issue #615

### DIFF
--- a/onnxmltools/convert/sparkml/utils.py
+++ b/onnxmltools/convert/sparkml/utils.py
@@ -15,7 +15,7 @@ def buildInitialTypesSimple(dataframe):
 
 def getTensorTypeFromSpark(sparktype):
     if sparktype == 'StringType' or sparktype == 'StringType()':
-        return StringTensorType([1, 1])
+        return StringTensorType([None, 1])
     elif sparktype == 'DecimalType' or sparktype == 'DecimalType()' \
             or sparktype == 'DoubleType' or sparktype == 'DoubleType()' \
             or sparktype == 'FloatType' or sparktype == 'FloatType()' \
@@ -24,7 +24,7 @@ def getTensorTypeFromSpark(sparktype):
             or sparktype == 'ShortType' or sparktype == 'ShortType()' \
             or sparktype == 'ByteType' or sparktype == 'ByteType()' \
             or sparktype == 'BooleanType' or sparktype == 'BooleanType()':
-        return FloatTensorType([1, 1])
+        return FloatTensorType([None, 1])
     else:
         raise TypeError("Cannot map this type to Onnx types: " + sparktype)
 

--- a/onnxmltools/convert/sparkml/utils.py
+++ b/onnxmltools/convert/sparkml/utils.py
@@ -33,7 +33,7 @@ def buildInputDictSimple(dataframe):
     import numpy
     result = {}
     for field in dataframe.schema.fields:
-        if str(field.dataType) == 'StringType':
+        if str(field.dataType) == 'StringType' or str(field.dataType) == 'StringType()':
             result[field.name] = dataframe.select(field.name).toPandas().values
         else:
             result[field.name] = dataframe.select(field.name).toPandas().values.astype(numpy.float32)


### PR DESCRIPTION
Updated the following to resolve issue #615 :
1. getTensorTypeFromSpark() now returns tensor types of shape [None,1] to take in batch inputs
2. buildInputDictSimple() now works with string features of dataType 'StringType()'