### PR TITLE
Add check for base_score in _get_attributes function

### DIFF
--- a/onnxmltools/convert/xgboost/_parse.py
+++ b/onnxmltools/convert/xgboost/_parse.py
@@ -99,7 +99,10 @@ def _get_attributes(booster):
 
     if 'base_score' not in kwargs:
         kwargs['base_score'] = 0.5
+    elif isinstance(kwargs['base_score'], str):
+        kwargs['base_score'] = float(kwargs['base_score'])
     return kwargs
+
 
 
 class WrappedBooster:


### PR DESCRIPTION
In the _get_attributes function in xgboost/_parse.py, I've added a check for the base_score attribute. This change is necessary because base_score can sometimes be stored as a string, which can cause issues in subsequent computations that expect it to be a float.

The updated code now checks if base_score is not in kwargs and, if not, sets it to 0.5. If base_score is in kwargs and is a string, it converts it to a float.

Here's the updated code:

`if 'base_score' not in kwargs:
    kwargs['base_score'] = 0.5
elif isinstance(kwargs['base_score'], str):
    kwargs['base_score'] = float(kwargs['base_score'])
return kwargs
`

This change ensures that base_score is always a float, which should prevent potential type-related errors in the future.
