### PR TITLE
Handle issue with binary classifier setting output to [N,1] vs [N,2]

### DIFF
--- a/onnxmltools/convert/xgboost/shape_calculators/Classifier.py
+++ b/onnxmltools/convert/xgboost/shape_calculators/Classifier.py
@@ -27,12 +27,12 @@ def calculate_xgboost_classifier_output_shapes(operator):
     objective = params["objective"]
     n_estimators = get_n_estimators_classifier(xgb_node, params, js_trees)
     num_class = params.get("num_class", None)
-
-    if num_class is not None:
+    
+    if objective == "binary:logistic":
+        ncl = 2
+    elif num_class is not None:
         ncl = num_class
         n_estimators = ntrees // ncl
-    elif objective == "binary:logistic":
-        ncl = 2
     else:
         ncl = ntrees // n_estimators
         if objective == "reg:logistic" and ncl == 1:
@@ -46,7 +46,7 @@ def calculate_xgboost_classifier_output_shapes(operator):
         operator.outputs[0].type = Int64TensorType(shape=[N])
     else:
         operator.outputs[0].type = StringTensorType(shape=[N])
-    operator.outputs[1].type = operator.outputs[1].type = FloatTensorType([N, ncl])
+    operator.outputs[1].type = FloatTensorType([N, ncl])
 
 
 register_shape_calculator("XGBClassifier", calculate_xgboost_classifier_output_shapes)


### PR DESCRIPTION
There's an issue on binarry classifier when passing a booster object.

WrappedBooster will set num_class to 1 as trees//ntrees == 1 https://github.com/casassg/onnxmltools/blob/e7a2ef088fb336800d34bffa628abac79f1ecc14/onnxmltools/convert/xgboost/_parse.py#L100

This makes it such that when we try to calculate the ncl for the classifier we end up setting an output of N, 1 vs N,2 which is what ONNX will actually calculate. These produce errors on logs in onnx runtime.

Given binary:logistic will always produce [N,2] changing the order in the if clause should remove the error.

I can add a test to repro but wanted to send PR first for feedback.

Also removed a double assignation which I'm not certain why it was there.