### PR TITLE
Add type hints, mypy CI, CoreML tests, and fix pre-existing CoreML bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Run tests coreml
         if: matrix.os != 'windows-latest' && matrix.python_version != '3.13'
         run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install libomp
+          fi
           pip install coremltools
           pytest tests/coreml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
       - name: Run tests svmlib
         run: pytest tests/svmlib
 
+      - name: Run tests coreml
+        if: matrix.os != 'windows-latest' && matrix.python_version != '3.13'
+        run: |
+          pip install coremltools
+          pytest tests/coreml
+
       - name: Run tests h2o
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,23 @@
+name: Mypy Type Checker
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install mypy numpy onnx protobuf skl2onnx
+      - name: Run mypy
+        run: mypy onnxmltools

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This package relies on ONNX, NumPy, and ProtoBuf. If you are converting a model 
 8. H2O
 9. CatBoost
 
-ONNXMLTools is tested with Python **3.7+**.
+ONNXMLTools is tested with Python **3.9+**.
 
 # Examples
 

--- a/onnxmltools/convert/common/_registration.py
+++ b/onnxmltools/convert/common/_registration.py
@@ -3,12 +3,12 @@
 # This dictionary defines the converters which can be invoked in the conversion framework defined in topology.py. A key
 # in this dictionary is an operator's unique ID (e.g., string and type) while the associated value is the callable
 # object used to convert the operator specified by the key.
-_converter_pool = {}
+_converter_pool: dict[object, object] = {}
 
 # This dictionary defines the shape calculators which can be invoked in the conversion framework defined in
 # topology.py. A key in this dictionary is an operator's unique ID (e.g., string and type) while the associated value
 # is the callable object used to infer the output shape(s) for the operator specified by the key.
-_shape_calculator_pool = {}
+_shape_calculator_pool: dict[object, object] = {}
 
 
 def register_converter(operator_name, conversion_function, overwrite=False):

--- a/onnxmltools/convert/coreml/_parse.py
+++ b/onnxmltools/convert/coreml/_parse.py
@@ -83,9 +83,8 @@ def _parse_coreml_feature(feature_info, target_opset, batch_size=1):
         shape.append(raw_type.imageType.height)
         shape.append(raw_type.imageType.width)
         color_space_map = {10: "Gray8", 20: "Rgb8", 30: "Bgr8"}
-        return FloatTensorType(
+        t = FloatTensorType(
             shape,
-            color_space_map[color_space],
             doc_string=doc_string,
             denotation="IMAGE",
             channel_denotations=[
@@ -95,6 +94,8 @@ def _parse_coreml_feature(feature_info, target_opset, batch_size=1):
                 "DATA_FEATURE",
             ],
         )
+        t.color_space = color_space_map[color_space]
+        return t
     elif type_name == "multiArrayType":
         element_type_id = raw_type.multiArrayType.dataType
         shape = [d for d in raw_type.multiArrayType.shape]

--- a/onnxmltools/convert/coreml/_parse.py
+++ b/onnxmltools/convert/coreml/_parse.py
@@ -3,7 +3,6 @@
 import warnings
 from ..common._container import CoremlModelContainer, Topology
 from ..common.data_types import (
-    find_type_conversion,
     FloatTensorType,
     Int64TensorType,
     StringTensorType,
@@ -485,10 +484,7 @@ def _parse_neural_network_model(topology, parent_scope, model, inputs, outputs):
             variable.type = Int64TensorType(variable.type.shape)
 
         # Feed model input to the associated model input
-        operator_type = find_type_conversion(
-            source_type=variable.type, target_type=child_variable.type
-        )
-        operator = scope.declare_local_operator(operator_type)
+        operator = scope.declare_local_operator("identity")
         operator.inputs.append(variable)
         operator.outputs.append(child_variable)
 

--- a/onnxmltools/convert/coreml/convert.py
+++ b/onnxmltools/convert/coreml/convert.py
@@ -9,6 +9,8 @@ from ..common.onnx_ex import get_maximum_opset_supported
 from ._parse import parse_coreml
 
 # Import modules to invoke function registrations
+from . import shape_calculators  # noqa: F401
+from . import operator_converters  # noqa: F401
 
 
 def convert(

--- a/onnxmltools/convert/coreml/convert.py
+++ b/onnxmltools/convert/coreml/convert.py
@@ -54,8 +54,8 @@ def convert(
         initial_type = [('A', FloatTensorType([40, 12, 1, 1])),
                         ('B', FloatTensorType([1, 32, 1, 1]))]
     """
-    from . import shape_calculators  # registers shape calculators as side effect
-    from . import operator_converters  # registers converters as side effect
+    from . import shape_calculators  # noqa: F401 - registers shape calculators as side effect
+    from . import operator_converters  # noqa: F401 - registers converters as side effect
 
     if isinstance(model, coremltools.models.MLModel):
         spec = model.get_spec()

--- a/onnxmltools/convert/coreml/convert.py
+++ b/onnxmltools/convert/coreml/convert.py
@@ -8,11 +8,6 @@ from ..common._topology import convert_topology
 from ..common.onnx_ex import get_maximum_opset_supported
 from ._parse import parse_coreml
 
-# Import modules to invoke function registrations
-from . import shape_calculators  # noqa: F401
-from . import operator_converters  # noqa: F401
-
-
 def convert(
     model,
     name=None,
@@ -59,6 +54,9 @@ def convert(
         initial_type = [('A', FloatTensorType([40, 12, 1, 1])),
                         ('B', FloatTensorType([1, 32, 1, 1]))]
     """
+    from . import shape_calculators  # registers shape calculators as side effect
+    from . import operator_converters  # registers converters as side effect
+
     if isinstance(model, coremltools.models.MLModel):
         spec = model.get_spec()
     else:

--- a/onnxmltools/convert/coreml/operator_converters/__init__.py
+++ b/onnxmltools/convert/coreml/operator_converters/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To register converters for Core ML operators, import associated modules here.
+from . import neural_network  # noqa: F401
 from . import ArrayFeatureExtractor
 from . import DictVectorizer
 from . import FeatureVectorizer

--- a/onnxmltools/convert/coreml/operator_converters/neural_network/Add.py
+++ b/onnxmltools/convert/coreml/operator_converters/neural_network/Add.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from onnx import onnx_proto
+import onnx
 from ....common._registration import register_converter
 from ....common._apply_operation import apply_add
 
@@ -10,7 +10,7 @@ def convert_add(scope, operator, container):
         scaler_name = scope.get_unique_variable_name(operator.full_name + "_B")
         container.add_initializer(
             scaler_name,
-            onnx_proto.TensorProto.FLOAT,
+            onnx.TensorProto.FLOAT,
             [],
             [operator.raw_operator.add.alpha],
         )

--- a/onnxmltools/convert/coreml/shape_calculators/__init__.py
+++ b/onnxmltools/convert/coreml/shape_calculators/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To register shape calculators for Core ML operators, import associated modules here.
+from . import neural_network  # noqa: F401
 from . import ArrayFeatureExtractor
 from . import Classifier
 from . import DictVectorizer

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/BatchNorm.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/BatchNorm.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/BidirectionalLSTM.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/BidirectionalLSTM.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Crop.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Crop.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Dot.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Dot.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Embed.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Embed.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import Int64Type, Int64TensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Flatten.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Flatten.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/GRU.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/GRU.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/IdentityFloat.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/IdentityFloat.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/InnerProduct.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/InnerProduct.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/LSTM.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/LSTM.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Merge.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Merge.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Pad.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Pad.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Permute.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Permute.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType, Int64TensorType, StringTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Pool.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Pool.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Reduce.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Reduce.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/ReorganizeData.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/ReorganizeData.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Reshape.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Reshape.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/ReshapeStatic.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/ReshapeStatic.py
@@ -2,7 +2,7 @@
 
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/SequenceRepeat.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/SequenceRepeat.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Slice.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Slice.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Split.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Split.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/coreml/shape_calculators/neural_network/Upsample.py
+++ b/onnxmltools/convert/coreml/shape_calculators/neural_network/Upsample.py
@@ -3,7 +3,7 @@
 import copy
 from ....common._registration import register_shape_calculator
 from ....common.data_types import FloatTensorType
-from ....common.utils import (
+from ....common.shape_calculator import (
     check_input_and_output_numbers,
     check_input_and_output_types,
 )

--- a/onnxmltools/convert/libsvm/operator_converters/SVMConverter.py
+++ b/onnxmltools/convert/libsvm/operator_converters/SVMConverter.py
@@ -2,7 +2,6 @@
 
 import onnx as onnx_proto
 from ...common._registration import register_converter
-from ...common.utils import cast_list
 import numpy
 
 try:
@@ -159,7 +158,7 @@ class SVCConverter(SVMConverter):
         else:
             nb["attrs"]["rho"] = [svm_node.rho[0] * sign_rho]
 
-        class_labels = cast_list(int, svm_node.get_labels())
+        class_labels = list(map(int, svm_node.get_labels()))
         # Predictions are different when label are not sorted (multi-classification).
         class_labels.sort()
         nb["attrs"]["classlabels_ints"] = class_labels

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -445,9 +445,9 @@ def convert_tensorflow(
     custom_op_conversions: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> onnx.ModelProto:
-    import pkgutil
+    import importlib.util
 
-    if not pkgutil.find_loader("tf2onnx"):  # type: ignore[attr-defined]
+    if importlib.util.find_spec("tf2onnx") is None:
         raise RuntimeError(
             "tf2onnx is not installed, please install it before calling this function."
         )

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -447,7 +447,7 @@ def convert_tensorflow(
 ) -> onnx.ModelProto:
     import pkgutil
 
-    if not pkgutil.find_loader("tf2onnx"):
+    if not pkgutil.find_loader("tf2onnx"):  # type: ignore[attr-defined]
         raise RuntimeError(
             "tf2onnx is not installed, please install it before calling this function."
         )

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -413,6 +413,7 @@ def _convert_tf_wrapper(
         tf.import_graph_def(tf_graph_def, name="")
 
         if not input_names:
+            assert output_names is not None, "output_names must be provided when input_names is not set"
             input_nodes = list(_collect_input_nodes(tf_graph, output_names)[0])
             input_names = [nd_.outputs[0].name for nd_ in input_nodes]
         g = tf2onnx.tfonnx.process_tf_graph(

--- a/onnxmltools/convert/main.py
+++ b/onnxmltools/convert/main.py
@@ -1,21 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from typing import Any
 import warnings
 import packaging.version as pv
 import onnx
 from .common import utils
+from .common.data_types import DataType
+
+# (feature_name, data_type) pairs that describe the model's inputs
+InitialTypes = list[tuple[str, DataType]]
 
 
 def convert_coreml(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+) -> onnx.ModelProto:
     if targeted_onnx is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -40,17 +47,17 @@ def convert_coreml(
 
 
 def convert_keras(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    channel_first_inputs=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-    default_batch_size=1,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    channel_first_inputs: list[str] | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+    default_batch_size: int = 1,
+) -> onnx.ModelProto:
     """
     .. versionchanged:: 1.9.0
         The conversion is now using *tf2onnx*.
@@ -150,15 +157,15 @@ def convert_keras(
 
 
 def convert_libsvm(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+) -> onnx.ModelProto:
     if targeted_onnx is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -183,8 +190,12 @@ def convert_libsvm(
 
 
 def convert_catboost(
-    model, name=None, initial_types=None, doc_string="", target_opset=None
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+) -> onnx.ModelProto:
     try:
         from catboost.utils import convert_to_onnx_object
     except ImportError:
@@ -202,18 +213,18 @@ def convert_catboost(
 
 
 def convert_lightgbm(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-    without_onnx_ml=False,
-    zipmap=True,
-    split=None,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+    without_onnx_ml: bool = False,
+    zipmap: bool = True,
+    split: int | None = None,
+) -> onnx.ModelProto:
     if targeted_onnx is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -241,15 +252,15 @@ def convert_lightgbm(
 
 
 def convert_sklearn(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+) -> onnx.ModelProto:
     if targeted_onnx is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -278,16 +289,16 @@ def convert_sklearn(
 
 
 def convert_sparkml(
-    model,
-    name=None,
-    initial_types=None,
-    doc_string="",
-    target_opset=None,
-    targeted_onnx=None,
-    custom_conversion_functions=None,
-    custom_shape_calculators=None,
-    spark_session=None,
-):
+    model: Any,
+    name: str | None = None,
+    initial_types: InitialTypes | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    targeted_onnx: str | None = None,
+    custom_conversion_functions: dict[str, Any] | None = None,
+    custom_shape_calculators: dict[str, Any] | None = None,
+    spark_session: Any = None,
+) -> onnx.ModelProto:
     if targeted_onnx is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -312,7 +323,7 @@ def convert_sparkml(
     )
 
 
-def convert_xgboost(*args, **kwargs):
+def convert_xgboost(*args: Any, **kwargs: Any) -> onnx.ModelProto:
     if kwargs.get("targeted_onnx", None) is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -327,7 +338,7 @@ def convert_xgboost(*args, **kwargs):
     return convert(*args, **kwargs)
 
 
-def convert_h2o(*args, **kwargs):
+def convert_h2o(*args: Any, **kwargs: Any) -> onnx.ModelProto:
     if kwargs.get("targeted_onnx", None) is not None:
         warnings.warn(
             "targeted_onnx is deprecated. Use target_opset.", DeprecationWarning
@@ -342,7 +353,7 @@ def convert_h2o(*args, **kwargs):
     return convert(*args, **kwargs)
 
 
-def _collect_input_nodes(graph, outputs):
+def _collect_input_nodes(graph: Any, outputs: list[str]) -> tuple[set[Any], set[Any]]:
     nodes_to_keep = set()
     input_nodes = set()
     node_inputs = [graph.get_tensor_by_name(ts_).op for ts_ in outputs]
@@ -361,17 +372,17 @@ def _collect_input_nodes(graph, outputs):
 
 
 def _convert_tf_wrapper(
-    frozen_graph_def,
-    name=None,
-    input_names=None,
-    output_names=None,
-    doc_string="",
-    target_opset=None,
-    channel_first_inputs=None,
-    debug_mode=False,
-    custom_op_conversions=None,
-    **kwargs,
-):
+    frozen_graph_def: Any,
+    name: str | None = None,
+    input_names: list[str] | None = None,
+    output_names: list[str] | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    channel_first_inputs: list[str] | None = None,
+    debug_mode: bool = False,
+    custom_op_conversions: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> onnx.ModelProto:
     """
     convert a tensorflow graph def into a ONNX model proto, just like how keras does.
     :param graph_def: the frozen tensorflow graph
@@ -422,17 +433,17 @@ def _convert_tf_wrapper(
 
 
 def convert_tensorflow(
-    frozen_graph_def,
-    name=None,
-    input_names=None,
-    output_names=None,
-    doc_string="",
-    target_opset=None,
-    channel_first_inputs=None,
-    debug_mode=False,
-    custom_op_conversions=None,
-    **kwargs,
-):
+    frozen_graph_def: Any,
+    name: str | None = None,
+    input_names: list[str] | None = None,
+    output_names: list[str] | None = None,
+    doc_string: str = "",
+    target_opset: int | None = None,
+    channel_first_inputs: list[str] | None = None,
+    debug_mode: bool = False,
+    custom_op_conversions: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> onnx.ModelProto:
     import pkgutil
 
     if not pkgutil.find_loader("tf2onnx"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ include = ["onnxmltools*"]
 onnxmltools = ["**/*"]
 
 
+[tool.mypy]
+ignore_missing_imports = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
 [tool.ruff]
 
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,16 @@ warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 
+# Pre-existing issues in legacy modules — suppress until addressed in follow-up PRs
+[[tool.mypy.overrides]]
+module = [
+    "onnxmltools.convert.coreml.*",
+    "onnxmltools.convert.libsvm.*",
+    "onnxmltools.convert.common._apply_operation",
+    "onnxmltools.convert.sparkml.operator_converters.tree_ensemble_common",
+]
+ignore_errors = true
+
 [tool.ruff]
 
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ warn_unused_ignores = true
 # Pre-existing issues in legacy modules — suppress until addressed in follow-up PRs
 [[tool.mypy.overrides]]
 module = [
-    "onnxmltools.convert.coreml.*",
+    "onnxmltools.convert.coreml.operator_converters.*",
+    "onnxmltools.convert.coreml.shape_calculators.*",
+    "onnxmltools.convert.coreml.convert",
     "onnxmltools.convert.libsvm.*",
     "onnxmltools.convert.common._apply_operation",
     "onnxmltools.convert.sparkml.operator_converters.tree_ensemble_common",

--- a/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
+++ b/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
@@ -27,9 +27,10 @@ from onnxmltools.utils import dump_data_and_model
 try:
     from coremltools.converters.xgboost import convert as convert_xgb_to_coreml
     from xgboost import XGBRegressor
-    XGBOOST_AVAILABLE = True
-except Exception:
+except (ImportError, OSError):
     XGBOOST_AVAILABLE = False
+else:
+    XGBOOST_AVAILABLE = True
 
 TARGET_OPSET = min(DEFAULT_OPSET_NUMBER, onnx_opset_version())
 

--- a/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
+++ b/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
@@ -29,6 +29,14 @@ try:
     from xgboost import XGBRegressor
 except (ImportError, OSError):
     XGBOOST_AVAILABLE = False
+except Exception as e:
+    # XGBoostError (raised when libomp.dylib is missing on macOS) does not
+    # inherit from ImportError/OSError, so we check by name to avoid catching
+    # unrelated programming errors.
+    if type(e).__name__ == "XGBoostError":
+        XGBOOST_AVAILABLE = False
+    else:
+        raise
 else:
     XGBOOST_AVAILABLE = True
 

--- a/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
+++ b/tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py
@@ -19,12 +19,17 @@ try:
         setattr(sklearn.preprocessing, "Imputer", Imputer)
 except ImportError:
     from sklearn.preprocessing import Imputer
-from coremltools.converters.xgboost import convert as convert_xgb_to_coreml
 from onnx.defs import onnx_opset_version
 from onnxmltools.convert.common.onnx_ex import DEFAULT_OPSET_NUMBER
 from onnxmltools.convert.coreml import convert as convert_cml
-from xgboost import XGBRegressor
 from onnxmltools.utils import dump_data_and_model
+
+try:
+    from coremltools.converters.xgboost import convert as convert_xgb_to_coreml
+    from xgboost import XGBRegressor
+    XGBOOST_AVAILABLE = True
+except Exception:
+    XGBOOST_AVAILABLE = False
 
 TARGET_OPSET = min(DEFAULT_OPSET_NUMBER, onnx_opset_version())
 


### PR DESCRIPTION
## Summary

### New CI & type safety
- **Type hints** for all `convert_*` functions in `onnxmltools/convert/main.py`: added `InitialTypes` alias (`list[tuple[str, DataType]]`), typed all parameters and return types (`-> onnx.ModelProto`), uses `from __future__ import annotations` for compatibility
- **mypy** added to `pyproject.toml` (`[tool.mypy]`) with `ignore_missing_imports = true`; pre-existing errors in legacy converter modules suppressed via `[[tool.mypy.overrides]]` for incremental adoption
- **New CI workflow** `.github/workflows/mypy.yml` runs mypy on every push and PR
- **CoreML tests added to CI** — 12 test files existed but were never executed; now run on Ubuntu and macOS for Python 3.10–3.12

### Bug fixes (surfaced by adding mypy + CoreML tests to CI)

**`onnxmltools/convert/coreml/`**
- `_parse.py`: remove deleted `find_type_conversion` import; replace the single call site with `"identity"` (consistent with all other similar operator declarations in the same file)
- `_parse.py`: fix `TypeError` — `color_space` was passed as a stray positional arg to `FloatTensorType.__init__`, colliding with `doc_string`; now set as a dynamic attribute after construction
- `convert.py`: the `# Import modules to invoke function registrations` comment had no actual imports — add `shape_calculators` and `operator_converters` imports to trigger registration on load
- `shape_calculators/__init__.py` and `operator_converters/__init__.py`: neither imported the `neural_network` subpackage, so all NN shape calculators and converters were never registered
- 22 neural network shape calculators: `check_input_and_output_numbers` / `check_input_and_output_types` were moved from `common/utils.py` to `common/shape_calculator.py` — update all imports

**Other converters**
- `coreml/operator_converters/neural_network/Add.py`: `onnx.onnx_proto` submodule was removed; replace with direct `onnx.TensorProto` access
- `libsvm/operator_converters/SVMConverter.py`: `cast_list` was removed from `common/utils.py`; replace with `list(map(int, ...))`
- `convert/common/_registration.py`: add type annotations to `_converter_pool` / `_shape_calculator_pool`

**`convert/main.py`**
- Replace deprecated `pkgutil.find_loader` with `importlib.util.find_spec` to avoid mypy version-dependent typing inconsistencies
- Add `assert output_names is not None` guard in `_convert_tf_wrapper`

**Tests**
- `tests/coreml/test_cml_TreeEnsembleRegressorConverterXGBoost.py`: wrap top-level xgboost imports in try/except to prevent pytest collection crash on macOS where `libomp.dylib` is missing

### README
- Update tested Python version from `3.7+` to `3.9+` to match `requires-python = ">=3.9"` in `pyproject.toml`

## Test plan

- [x] mypy passes (0 errors, 195 files)
- [x] ruff passes
- [x] DCO passes
- [ ] CoreML tests pass on Ubuntu and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)